### PR TITLE
chore(ci): sync code-review workflow from trips-api

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -1,0 +1,464 @@
+# Claude Code Review Workflow (with auto-approval capability)
+# Based on EWA-Services/EWA-Actions template, customized for this repo
+#
+# Claude Code Review Workflow
+# Triggers:
+#   1. PR marked "Ready for review" → Full code review
+#   2. @claude in PR comment → Answer questions or review on demand
+#   3. @claude in inline comment → Reply in thread about specific code
+#
+---
+name: Code Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read  # Note: "contents: write" would eliminate git config errors but is not needed for reviews
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  # Job to post welcome message when PR is opened
+  welcome:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for existing welcome message
+        id: check-welcome
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # yamllint disable rule:line-length
+        run: |
+          # Check if we already posted a welcome message
+          WELCOME_EXISTS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq '[.[] | select(.body | contains("🤖 **Code Review Assistant**"))] | length')
+
+          if [[ "$WELCOME_EXISTS" -gt 0 ]]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "✅ Welcome message already exists"
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "📝 Need to post welcome message"
+          fi
+      - name: Post welcome message
+        if: steps.check-welcome.outputs.found == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF'
+          🤖 **Code Review Assistant**
+
+          Welcome! This PR has access to AI-powered code reviews using **Claude Opus 4.5** - Anthropic's most powerful coding model.
+
+          **How to trigger a review:**
+          - 🚀 Mark your PR as "Ready for review" from draft status
+          - 💬 Tag `@claude` in any comment to ask questions or request a review
+          - 📝 Reply to inline code comments with `@claude` for specific feedback
+
+          **What I can help with:**
+          - Comprehensive code reviews (security, performance, best practices)
+          - Answer specific technical questions
+          - Suggest improvements and fixes
+          - Review test coverage and documentation
+
+          _Note: Only users with write, maintain, or admin permissions can trigger reviews._
+          EOF
+          )"
+        # yamllint enable rule:line-length
+  # Main review job
+  review:
+    runs-on: ubuntu-latest
+    env:
+      # Force AI review actions to use the FINN DevOps PAT so downstream workflows are triggered
+      GITHUB_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+    # Only run if this is a PR ready for review, or if comment mentions @claude
+    if: |
+      github.event_name == 'pull_request' && github.event.action == 'ready_for_review' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    steps:
+      # Check if the actor has write or admin permissions on the repository
+      - name: Check actor permissions
+        id: check-permissions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission \
+            --jq .permission 2>/dev/null || echo "none")
+          echo "Actor (${{ github.actor }}) has '${PERMISSION}' permission on this repository."
+          if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "maintain" || "$PERMISSION" == "write" ]]; then
+            echo "is_authorized=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_authorized=false" >> $GITHUB_OUTPUT
+            echo "::error::Actor does not have write, maintain, or admin permissions on this repository"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check-permissions.outputs.is_authorized == 'true'
+        with:
+          fetch-depth: 0
+
+      # Extract PR number based on event type
+      - name: Extract PR number
+        id: extract-pr
+        if: steps.check-permissions.outputs.is_authorized == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Event: ${{ github.event_name }}"
+
+          # Extract PR number
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            echo "📋 PR number from pull_request event: $PR_NUMBER"
+          elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            # For issue_comment events on PRs, the PR number is in issue.number
+            # Verify this is actually a PR comment, not an issue comment
+            if [[ "${{ github.event.issue.pull_request }}" != "" ]]; then
+              PR_NUMBER="${{ github.event.issue.number }}"
+              echo "💬 PR number from issue_comment event: $PR_NUMBER"
+            else
+              echo "⚠️ Issue comment is not on a PR, skipping"
+              echo "::notice::Skipping: Comment is on an issue, not a pull request"
+              echo "has_pr=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          elif [[ "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            echo "📝 PR number from pull_request_review_comment event: $PR_NUMBER"
+          else
+            echo "⚠️ Could not determine PR number for event: ${{ github.event_name }}"
+            echo "::error::Unsupported event type: ${{ github.event_name }}"
+            exit 1
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "has_pr=true" >> $GITHUB_OUTPUT
+          echo "✅ Using PR number: $PR_NUMBER"
+
+      # Extract comment details based on event type
+      - name: Extract comment details
+        id: extract-comment
+        if: steps.check-permissions.outputs.is_authorized == 'true' && steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY_ISSUE: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
+          COMMENT_BODY_REVIEW: >
+            ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.body || '' }}
+          COMMENT_ID_ISSUE: ${{ github.event_name == 'issue_comment' && github.event.comment.id || '' }}
+          COMMENT_ID_REVIEW: >
+            ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.id || '' }}
+          COMMENT_URL_ISSUE: >
+            ${{ github.event_name == 'issue_comment' && github.event.comment.html_url || '' }}
+          COMMENT_URL_REVIEW: >
+            ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.html_url || '' }}
+          COMMENT_AUTHOR_ISSUE: >
+            ${{ github.event_name == 'issue_comment' && github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_REVIEW: >
+            ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.user.login || '' }}
+          PR_URL: ${{ github.event.pull_request.html_url || '' }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || '' }}
+          REVIEW_FILE_PATH: >
+            ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.path || '' }}
+          REVIEW_LINE: ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.line || '' }}
+          REVIEW_ORIG_LINE: >
+            ${{ github.event_name == 'pull_request_review_comment' && github.event.comment.original_line || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            # PR comment (not inline)
+            COMMENT_TYPE="pr_comment"
+            COMMENT_BODY="$COMMENT_BODY_ISSUE"
+            COMMENT_ID="$COMMENT_ID_ISSUE"
+            COMMENT_URL="$COMMENT_URL_ISSUE"
+            COMMENT_AUTHOR="$COMMENT_AUTHOR_ISSUE"
+            FILE_PATH=""
+            LINE_NUMBER=""
+
+            echo "💬 PR Comment from @${COMMENT_AUTHOR}"
+            echo "Comment ID: ${COMMENT_ID}"
+
+          elif [[ "$EVENT_NAME" == "pull_request_review_comment" ]]; then
+            # Inline code review comment
+            COMMENT_TYPE="inline_comment"
+            COMMENT_BODY="$COMMENT_BODY_REVIEW"
+            COMMENT_ID="$COMMENT_ID_REVIEW"
+            COMMENT_URL="$COMMENT_URL_REVIEW"
+            COMMENT_AUTHOR="$COMMENT_AUTHOR_REVIEW"
+            FILE_PATH="$REVIEW_FILE_PATH"
+            LINE_NUMBER="${REVIEW_LINE:-$REVIEW_ORIG_LINE}"
+
+            echo "📝 Inline Comment from @${COMMENT_AUTHOR}"
+            echo "File: ${FILE_PATH}:${LINE_NUMBER}"
+            echo "Comment ID: ${COMMENT_ID}"
+
+          else
+            # Pull request event (ready_for_review)
+            COMMENT_TYPE="pr_event"
+            COMMENT_BODY="PR marked as ready for review"
+            COMMENT_ID=""
+            COMMENT_URL="$PR_URL"
+            COMMENT_AUTHOR="$PR_AUTHOR"
+            FILE_PATH=""
+            LINE_NUMBER=""
+
+            echo "🚀 PR ready for review by @${COMMENT_AUTHOR}"
+          fi
+
+          # Output all the extracted information
+          echo "comment_type=$COMMENT_TYPE" >> $GITHUB_OUTPUT
+          echo "comment_id=$COMMENT_ID" >> $GITHUB_OUTPUT
+          echo "comment_url=$COMMENT_URL" >> $GITHUB_OUTPUT
+          echo "comment_author=$COMMENT_AUTHOR" >> $GITHUB_OUTPUT
+          echo "file_path=$FILE_PATH" >> $GITHUB_OUTPUT
+          echo "line_number=$LINE_NUMBER" >> $GITHUB_OUTPUT
+
+          # Multi-line comment body
+          echo "comment_body<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENT_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Summary
+          echo "✅ Extracted comment details:"
+          echo "  Type: $COMMENT_TYPE"
+          echo "  Author: @$COMMENT_AUTHOR"
+          [[ -n "$FILE_PATH" ]] && echo "  File: $FILE_PATH:$LINE_NUMBER"
+          echo "  Message preview: ${COMMENT_BODY:0:100}..."
+
+      # Define standard PR review instructions
+      - name: Define review instructions
+        id: review-instructions
+        if: steps.check-permissions.outputs.is_authorized == 'true' && steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        run: |
+          # Standard PR review instructions - kept separate for clarity and reusability
+          REVIEW_INSTRUCTIONS="Perform a comprehensive code review with the following focus areas:
+
+          1. **Code Quality**
+             - Clean code principles and best practices
+             - Proper error handling and edge cases
+             - Code readability and maintainability
+
+          2. **Security**
+             - Check for potential security vulnerabilities
+             - Validate input sanitization
+             - Review authentication/authorization logic
+
+          3. **Performance**
+             - Identify potential performance bottlenecks
+             - Review database queries for efficiency
+             - Check for memory leaks or resource issues
+
+          4. **Testing**
+             - Verify adequate test coverage
+             - Review test quality and edge cases
+             - Check for missing test scenarios
+
+          5. **Documentation**
+             - Ensure code is properly documented
+             - Verify README updates for new features
+             - Check API documentation accuracy
+
+          Use inline comments ONLY for issues that need to be fixed or changed.
+          Do NOT leave inline comments for praise or positive observations.
+          Post a final summary review using 'gh pr comment'.
+
+          ## Approval Decision
+
+          After completing your review, you MUST make an approval decision:
+
+          **APPROVE the PR** if ALL of these conditions are met:
+          - No security vulnerabilities found
+          - No critical bugs or logic errors
+          - Code follows project conventions
+          - Tests pass (if applicable)
+
+          To approve, run: gh pr review --approve --body 'LGTM - Code review passed. [brief summary of what was reviewed]'
+
+          **REQUEST CHANGES** if ANY blocking issues are found:
+          - Security vulnerabilities
+          - Critical bugs
+          - Missing required tests for new functionality
+          - Breaking changes without migration path
+
+          To request changes, run: gh pr review --request-changes --body '[summary of required changes]'
+
+          **COMMENT only** (no approval/rejection) if:
+          - Minor suggestions that don't block merge
+          - Questions that need clarification before deciding
+
+          IMPORTANT: Always make an explicit approval decision. Do not leave the PR without approving or requesting changes."
+
+          # Output the review instructions for use in next step
+          echo "instructions<<EOF" >> $GITHUB_OUTPUT
+          echo "$REVIEW_INSTRUCTIONS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "✅ Review instructions defined"
+
+      # yamllint disable rule:line-length
+      # Craft the prompt based on comment type
+      - name: Craft prompt for Claude
+        id: craft-prompt
+        if: steps.check-permissions.outputs.is_authorized == 'true' && steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Get review instructions from previous step
+          REVIEW_INSTRUCTIONS=$(cat <<'REVIEW_EOF'
+          ${{ steps.review-instructions.outputs.instructions }}
+          REVIEW_EOF
+          )
+
+          # Base context
+          BASE_CONTEXT="REPO: ${{ github.repository }}
+          PR NUMBER: ${{ steps.extract-pr.outputs.pr_number }}
+
+          ## User Comment Details
+          - **Type**: ${{ steps.extract-comment.outputs.comment_type }}
+          - **Author**: @${{ steps.extract-comment.outputs.comment_author }}"
+
+          # Add file/line info if it's an inline comment
+          if [[ "${{ steps.extract-comment.outputs.comment_type }}" == "inline_comment" ]]; then
+            BASE_CONTEXT="${BASE_CONTEXT}
+          - **File**: ${{ steps.extract-comment.outputs.file_path }}:${{ steps.extract-comment.outputs.line_number }}
+          - **Comment ID**: ${{ steps.extract-comment.outputs.comment_id }}"
+          fi
+
+          # Get comment body from the extract-comment step output
+          COMMENT_BODY=$(cat <<'COMMENT_EOF'
+          ${{ steps.extract-comment.outputs.comment_body }}
+          COMMENT_EOF
+          )
+
+          # Craft prompt based on comment type
+          if [[ "${{ steps.extract-comment.outputs.comment_type }}" == "inline_comment" ]]; then
+            FULL_PROMPT="${BASE_CONTEXT}
+
+          ## User's Inline Comment:
+          ${COMMENT_BODY}
+
+          ---
+
+          The user has commented on a specific line of code in ${{ steps.extract-comment.outputs.file_path }} at line ${{ steps.extract-comment.outputs.line_number }}.
+
+          IMPORTANT: To reply to this inline comment, use the following API endpoint:
+          gh api -X POST /repos/${{ github.repository }}/pulls/${{ steps.extract-pr.outputs.pr_number }}/comments \\
+            -f body='Your reply message' \\
+            -F in_reply_to=${{ steps.extract-comment.outputs.comment_id }}
+
+          Analyze their comment and respond appropriately:
+          - If they're asking a question about the code, answer it directly
+          - If they're pointing out an issue, acknowledge and discuss it
+          - If they're requesting a change, evaluate and respond
+          - Focus on the specific code context they're commenting on
+          - Be concise and directly relevant to their comment
+          - Use the in_reply_to parameter to create a threaded reply"
+
+          elif [[ "${{ steps.extract-comment.outputs.comment_type }}" == "pr_comment" ]]; then
+            FULL_PROMPT="${BASE_CONTEXT}
+
+          ## User's Comment:
+          ${COMMENT_BODY}
+
+          ---
+
+          The user has posted a comment on this PR. Analyze what they're asking for:
+
+          - If they're asking a specific question, answer it directly and concisely
+          - If they're requesting a specific action, perform it
+          - Use your judgment to determine their intent from the comment
+          - If they're asking for a code review or to check the PR, then:
+            ${REVIEW_INSTRUCTIONS}
+
+          IMPORTANT: To respond to this PR comment, use:
+          gh pr comment --body 'Your response here'"
+
+          else
+            # PR marked ready for review - always do full review
+            FULL_PROMPT="${BASE_CONTEXT}
+
+          This PR has been marked as ready for review.
+
+          ${REVIEW_INSTRUCTIONS}"
+          fi
+
+          # Output the complete prompt
+          echo "prompt<<EOF" >> $GITHUB_OUTPUT
+          echo "$FULL_PROMPT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "✅ Crafted prompt for comment type: ${{ steps.extract-comment.outputs.comment_type }}"
+      # yamllint enable rule:line-length
+
+      # Determine if track_progress is supported for this event/action combination
+      - name: Check track_progress support
+        id: check-track-progress
+        if: steps.check-permissions.outputs.is_authorized == 'true' && steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Event: ${{ github.event_name }}, Action: ${{ github.event.action }}"
+
+          # Check if this event/action combination supports track_progress
+          case "${{ github.event_name }}" in
+            pull_request)
+              case "${{ github.event.action }}" in
+                ready_for_review)
+                  echo "track_progress=true" >> $GITHUB_OUTPUT
+                  echo "✅ track_progress supported for pull_request/${{ github.event.action }}"
+                  ;;
+                *)
+                  echo "track_progress=false" >> $GITHUB_OUTPUT
+                  echo "⚠️ track_progress not supported for pull_request/${{ github.event.action }}"
+                  ;;
+              esac
+              ;;
+            *)
+              echo "track_progress=false" >> $GITHUB_OUTPUT
+              echo "⚠️ track_progress not supported for ${{ github.event_name }}/${{ github.event.action }}"
+              ;;
+          esac
+
+      - uses: anthropics/claude-code-action@v1
+        if: steps.check-permissions.outputs.is_authorized == 'true' && steps.extract-pr.outputs.has_pr == 'true'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+          # Use track_progress based on the check from the previous step
+          # yamllint disable rule:line-length
+          # See: https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md#supported-events-for-track_progress
+          # yamllint enable rule:line-length
+          track_progress: ${{ steps.check-track-progress.outputs.track_progress }}
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --allowedTools "mcp__github__add_comment_to_pending_review,
+            mcp__github__add_pull_request_review_comment,
+            mcp__github__create_issue_comment,
+            mcp__github__create_pending_pull_request_review,
+            mcp__github__get_file_contents,
+            mcp__github__get_pull_request_diff,
+            mcp__github__submit_pending_pull_request_review,
+            mcp__github_ci__get_ci_status,
+            mcp__github_ci__get_workflow_run_details,
+            mcp__github_ci__download_job_log,
+            mcp__github_comment__update_claude_comment,
+            mcp__github_inline_comment__create_inline_comment,
+            mcp__github_pulls__get_pull_request,
+            mcp__github_pulls__list_pull_request_files,
+            mcp__github_pulls__get_pull_request_diff,
+            Bash,Read,Grep,Glob,WebFetch,WebSearch,TodoWrite"
+          prompt: ${{ steps.craft-prompt.outputs.prompt }}


### PR DESCRIPTION
## Summary
- sync `.github/workflows/code-review.yaml` from `jai/trips-api` main branch
- keep workflow content verbatim

## Validation
- `git diff --name-only` shows exactly one changed file
