### PR TITLE
feat(ci): make code-review workflow reusable via workflow_call

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -11,12 +11,12 @@
 name: Code Review
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request:
-    types: [opened, reopened, ready_for_review]
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+      CLAUDE_REVIEW_GH_TOKEN:
+        required: true
 
 permissions:
   contents: read  # Note: "contents: write" would eliminate git config errors but is not needed for reviews
@@ -35,7 +35,7 @@ jobs:
       - name: Check for existing welcome message
         id: check-welcome
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         # yamllint disable rule:line-length
         run: |
           # Check if we already posted a welcome message
@@ -52,7 +52,7 @@ jobs:
       - name: Post welcome message
         if: steps.check-welcome.outputs.found == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF'
           🤖 **Code Review Assistant**
@@ -91,7 +91,7 @@ jobs:
       - name: Check actor permissions
         id: check-permissions
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission \
             --jq .permission 2>/dev/null || echo "none")


### PR DESCRIPTION
## What
- Convert `code-review.yaml` to a reusable workflow using `on.workflow_call`.
- Require `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_REVIEW_GH_TOKEN` as reusable-workflow secrets.
- Switch internal default token usage from `secrets.GITHUB_TOKEN` to `github.token`.

## Why
- Centralize Trips code-review logic in one source of truth.
- Allow `trips-*` repos to call this workflow and avoid future drift.

## How to test
- In a caller repo, use `jobs.<id>.uses: jai/trips-ci/.github/workflows/code-review.yaml@main` with the two Claude secrets.
- Trigger with `@claude` comment on an open PR and verify workflow runs.
