### PR TITLE
fix(ci): keep reusable workflow permissions compatible

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -20,7 +20,7 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
   actions: read


### PR DESCRIPTION
## Summary\n- revert reusable workflow permissions.contents back to read\n- keep PAT-backed checkout token for branch push operations\n- restore compatibility with caller workflows that grant contents:read\n\n## Validation\n- yq e '.' .github/workflows/code-review.yaml\n