### PR TITLE
fix(ci): fallback ready decision to review state

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -585,10 +585,38 @@ jobs:
           ')
 
           if [[ -z "$DECISION_BODY" ]]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No structured ready decision marker found after ${RUN_STARTED_AT}; skipping auto ready."
-            exit 0
+            REVIEWS_JSON=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --paginate)
+            REVIEW_STATE=$(printf '%s' "$REVIEWS_JSON" | jq -r --arg run_started_at "$RUN_STARTED_AT" --arg automation_login "$AUTOMATION_LOGIN" '
+              [
+                .[]
+                | select(.user.login == $automation_login)
+                | select(.submitted_at != null and .submitted_at >= $run_started_at)
+              ]
+              | sort_by(.submitted_at)
+              | last
+              | .state // empty
+            ' | tr '[:upper:]' '[:lower:]')
+
+            case "$REVIEW_STATE" in
+              approved)
+                echo "found=true" >> "$GITHUB_OUTPUT"
+                echo "ready=true" >> "$GITHUB_OUTPUT"
+                echo "✅ Structured marker missing; falling back to review state APPROVED."
+                exit 0
+                ;;
+              changes_requested|commented|dismissed)
+                echo "found=true" >> "$GITHUB_OUTPUT"
+                echo "ready=false" >> "$GITHUB_OUTPUT"
+                echo "ℹ️ Structured marker missing; review state is ${REVIEW_STATE}."
+                exit 0
+                ;;
+              *)
+                echo "found=false" >> "$GITHUB_OUTPUT"
+                echo "ready=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::No structured ready marker or qualifying review state found after ${RUN_STARTED_AT}; skipping auto ready."
+                exit 0
+                ;;
+            esac
           fi
 
           READY_VALUE=$(printf '%s\n' "$DECISION_BODY" \


### PR DESCRIPTION
## Summary\n- keep structured marker parsing for READY_FOR_REVIEW when present\n- add deterministic fallback to automation review state when marker is missing\n- treat approved as ready=true and changes_requested/commented as ready=false\n\n## Validation\n- yq e '.' .github/workflows/code-review.yaml\n