### PR TITLE
fix(ci): use opus alias for claude reviewer model

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -537,7 +537,7 @@ jobs:
           github_token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
           track_progress: ${{ steps.check-track-progress.outputs.track_progress }}
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model opus
             --allowedTools "mcp__github__add_comment_to_pending_review,
             mcp__github__add_pull_request_review_comment,
             mcp__github__create_issue_comment,


### PR DESCRIPTION
## Summary\n- switch reviewer model argument from pinned claude-opus-4-5-20251101 to the opus alias\n- keep all other workflow behavior unchanged\n\n## Validation\n- yq e '.' .github/workflows/code-review.yaml\n