### PR TITLE
fix(ci): require copilot to update existing pr branch

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -269,6 +269,9 @@ jobs:
             - Post exactly ONE PR comment addressed to @copilot with a clear, actionable list of required code changes.
             - Include file paths, expected behavior, and acceptance criteria for each requested change.
             - Keep the comment implementation-focused so Copilot can push commits directly.
+            - Explicitly instruct @copilot to push commits to this existing PR branch (update this PR directly).
+            - Do not ask @copilot to open a new PR/sub-PR unless branch permissions make direct pushes impossible.
+            - If direct push is impossible, require @copilot to state the exact constraint before opening any fallback PR.
             - Treat code sanity, cleanup, and maintainability as first-class review concerns, not optional nice-to-haves.
             - If maintainability/cleanup issues are reasonably fixable in this PR, explicitly instruct @copilot to implement them now in this same PR.
             - Do not defer cleanup to future PRs unless the change is truly out of scope or too risky; if deferred, state why.


### PR DESCRIPTION
## Summary
- tighten copilot-handoff instructions in shared `code-review.yaml`
- explicitly require `@copilot` to push commits to the existing PR branch
- forbid new PR/sub-PR creation unless direct branch push is impossible, and require explicit constraint disclosure

## Why
- recent handoff on frontend PR #174 spawned empty sub-PRs targeting the parent branch
- this change biases Copilot toward updating the original PR directly
