### PR TITLE
fix(ci): cap claude review job runtime at 30 minutes

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -78,6 +78,7 @@ jobs:
   # Main review job
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # Force AI review actions to use the FINN DevOps PAT so downstream workflows are triggered
       GITHUB_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- add `timeout-minutes: 30` to the reusable `review` job in `.github/workflows/code-review.yaml`
- ensure hung Claude review executions terminate automatically
- keep behavior unchanged for normal successful runs