### PR TITLE
feat: add shared auto-merge workflow + remove prompt instruction

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,26 @@
+# Auto-Merge Workflow
+# Enables auto-merge (squash) on PRs as soon as they're opened.
+# Merge won't happen until all branch protection / ruleset requirements are met.
+# Called by downstream repos via workflow_call.
+---
+name: Auto-Merge
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        run: |
+          gh pr merge --auto --squash \
+            "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -310,8 +310,6 @@ jobs:
             - Tests pass (if applicable)
 
             To approve, run: gh pr review --approve --body 'LGTM - Code review passed. [brief summary of what was reviewed]'
-            After approving, enable auto-merge with:
-            gh pr merge --auto --repo ${{ github.repository }} ${{ steps.extract-pr.outputs.pr_number }}
 
             **REQUEST CHANGES** only if hard-blocked after attempting direct fixes:
             - You cannot push required changes from this workflow


### PR DESCRIPTION
## Summary

Two changes in one PR (both in `trips-ci`):

1. **New `auto-merge.yaml` shared workflow** — enables auto-merge (squash) when a PR is opened or marked ready. Called by downstream repos via `workflow_call`.

2. **Remove `gh pr merge --auto` from code-review prompt** — auto-merge is now handled by the dedicated workflow, not by Claude remembering to run a command.

## Why

The previous approach relied on Claude executing `gh pr merge --auto --squash` as part of its review. This was unreliable — Claude sometimes skipped it, leaving PRs approved but not queued for merge.

The new workflow runs once per PR (~10s), fires on `opened` + `ready_for_review`, and is completely deterministic.

## Safety

- `if: !github.event.pull_request.draft` guard prevents errors on draft PRs
- All repos have rulesets requiring CI + reviews + thread resolution — auto-merge won't fire until all are met
- Only squash merge is enabled across all repos

Closes #24
Closes #25
Ref #23
