### PR TITLE
ci: move workflows to Ubicloud runners

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   enable-auto-merge:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Enable auto-merge (squash)
         run: |

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   # Job to post welcome message when PR is opened
   welcome:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
         # yamllint enable rule:line-length
   # Main review job
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     timeout-minutes: 30
     env:
       # Force AI review actions to use the FINN DevOps PAT so downstream workflows are triggered

--- a/.github/workflows/coverage-octocov.yml
+++ b/.github/workflows/coverage-octocov.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   octocov:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What
- Switch GitHub Actions runners from `ubuntu-latest` to `ubicloud-standard-2` in workflow files.

## Why
- Reduce CI runner cost while keeping workflow behavior the same.
- Standardize runner label usage across Trips repositories.

## How to test
- Confirm `.github/workflows/*` now use `runs-on: ubicloud-standard-2`.
- Trigger a workflow (or open this PR) and verify jobs start on the Ubicloud runner label.
