### PR TITLE
fix(ci): escape backticks in review instructions to prevent shell expansion

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -326,7 +326,7 @@ jobs:
 
             ## Review Thread Resolution (MANDATORY — zero unresolved threads before approve)
             Before finalizing, you MUST inspect ALL open review threads on this PR and resolve every single one.
-            Use `gh api graphql` with the `resolveReviewThread` mutation to resolve threads programmatically.
+            Use gh api graphql with the resolveReviewThread mutation to resolve threads programmatically.
 
             For each unresolved thread, apply ONE of these actions:
             1. **Valid suggestion** → Implement the fix, push a commit, reply confirming the fix, then RESOLVE the thread.


### PR DESCRIPTION
Backticks in the double-quoted REVIEW_INSTRUCTIONS bash string were shell-expanded, causing `resolveReviewThread: command not found` (exit 127). Removed backticks from prose text.