### PR TITLE
refactor(ci): extract review instructions to prevent shell quoting issues

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -253,7 +253,8 @@ jobs:
         if: steps.extract-pr.outputs.has_pr == 'true'
         shell: bash
         run: |
-          REVIEW_INSTRUCTIONS="Perform a comprehensive code review with the following focus areas:
+          REVIEW_INSTRUCTIONS=$(cat <<'REVIEW_INSTRUCTIONS_EOF'
+          Perform a comprehensive code review with the following focus areas:
 
             1. **Code Quality**
                - Clean code principles and best practices
@@ -348,7 +349,9 @@ jobs:
             <!-- /CLAUDE_READY_DECISION -->
 
             Set READY_FOR_REVIEW=true only when your final review decision is APPROVE.
-            Set READY_FOR_REVIEW=false for request-changes or comment-only outcomes."
+            Set READY_FOR_REVIEW=false for request-changes or comment-only outcomes.
+          REVIEW_INSTRUCTIONS_EOF
+          )
 
           # Output the review instructions for use in next step
           echo "instructions<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- refactored the `Define review instructions` step in `.github/workflows/code-review.yaml` to use a single-quoted heredoc (`<<'REVIEW_INSTRUCTIONS_EOF'`) instead of an inline double-quoted bash string
- preserved the review prompt content while removing shell-quoting fragility from that block
- kept workflow triggers, job structure, and downstream caller behavior unchanged

## Why
The previous inline `REVIEW_INSTRUCTIONS="..."` block was fragile to bash metacharacters in prompt text (e.g. accidental unescaped `"`, backticks, `$()`), making routine prompt edits risky.

## Validation
- `bash -n /tmp/review-instructions.sh`
- `GITHUB_OUTPUT=/tmp/review-instructions.out bash -euo pipefail /tmp/review-instructions.sh`

Both passed locally.
