### PR TITLE
feat: reusable PR image URL validation workflow

### DIFF
--- a/.github/workflows/pr-image-check.yaml
+++ b/.github/workflows/pr-image-check.yaml
@@ -1,0 +1,96 @@
+name: PR Image Check
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-images:
+    name: Validate PR Images
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Check image URLs in PR body
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Fetch PR body
+          BODY=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""')
+
+          if [ -z "$BODY" ]; then
+            echo "ℹ️ No PR body found — skipping"
+            exit 0
+          fi
+
+          # Extract image URLs (two passes, deduplicated):
+          # 1) Markdown image syntax: ![alt](url)
+          # 2) Raw URLs ending in image extensions
+          URLS=$(
+            {
+              echo "$BODY" | grep -oP '!\[[^\]]*\]\(\K[^\)]+' || true
+              echo "$BODY" | grep -oP 'https?://[^\s\)"<>]+\.(?:png|jpg|jpeg|gif|webp|svg)(?=[\s\)"<>]|$)' || true
+            } | sort -u
+          )
+
+          if [ -z "$URLS" ]; then
+            echo "ℹ️ No images in PR body"
+            exit 0
+          fi
+
+          echo "🔍 Found image URLs:"
+          echo "$URLS"
+          echo ""
+
+          FAILURES=""
+          CHECKED=0
+          FAILED=0
+
+          while IFS= read -r url; do
+            [ -z "$url" ] && continue
+            CHECKED=$((CHECKED + 1))
+
+            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+              -L --max-time 10 \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              "$url" 2>/dev/null || echo "000")
+
+            if [[ "$HTTP_CODE" =~ ^2[0-9]{2}$ ]]; then
+              echo "  ✅ ${HTTP_CODE} — ${url}"
+            else
+              echo "  ❌ ${HTTP_CODE} — ${url}"
+              FAILED=$((FAILED + 1))
+              FAILURES="${FAILURES}\n- \`${url}\` → HTTP ${HTTP_CODE}"
+            fi
+          done <<< "$URLS"
+
+          echo ""
+          echo "Checked ${CHECKED} URL(s): ${FAILED} broken"
+
+          if [ "$FAILED" -gt 0 ]; then
+            COMMENT_BODY=$(cat <<EOF
+          ⚠️ **Broken image(s) in PR description**
+
+          The following image URL(s) returned non-2xx status codes:
+
+          $(echo -e "$FAILURES")
+
+          Please update or remove these URLs before merging.
+          EOF
+          )
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="$COMMENT_BODY" --silent
+            echo ""
+            echo "❌ Posted comment with broken URLs — failing check"
+            exit 1
+          fi
+
+          echo "✅ All ${CHECKED} image URL(s) resolved successfully"


### PR DESCRIPTION
## What

Adds a reusable workflow (`pr-image-check.yaml`) that validates image URLs in PR descriptions aren't broken (404/non-2xx).

## How it works

1. Fetches the PR body via `gh api`
2. Extracts image URLs using two patterns:
   - Markdown: `![alt](url)`
   - Raw URLs ending in `.png/.jpg/.jpeg/.gif/.webp/.svg`
3. Curls each URL with `Authorization: Bearer $GH_TOKEN` and follows redirects
4. If any URL returns non-2xx:
   - Posts a PR comment listing the broken URLs
   - Fails the check
5. If no images found: passes with notice
6. If all resolve: passes

## Consumer PR

- trips-frontend: https://github.com/jai/trips-frontend/pull/272

## Testing

URL extraction tested against sample markdown with:
- Markdown image syntax (`![alt](url)`)
- Raw image URLs on their own lines
- Inline raw URLs
- Non-image URLs (correctly excluded)