### PR TITLE
ci: run code reviews through Codex CLI

### DIFF
--- a/.github/workflows/code-review-full.yaml
+++ b/.github/workflows/code-review-full.yaml
@@ -1,4 +1,4 @@
-# Claude Full Review Workflow (reusable)
+# Codex Full Review Workflow (reusable)
 # Extracted from code-review.yaml full-review path.
 # Handles:
 #   1. pull_request events (opened, reopened, ready_for_review, synchronize, review_requested)
@@ -6,7 +6,7 @@
 # CI owns final approve/request-changes orchestration.
 
 ---
-name: Claude Full Review
+name: Codex Full Review
 
 on:
   workflow_call:
@@ -16,14 +16,29 @@ on:
         type: string
         required: false
         default: ""
+      codex_version:
+        description: Codex CLI version to install (latest or exact semver)
+        type: string
+        required: false
+        default: latest
+      codex_model:
+        description: Codex model to use for direct CLI review
+        type: string
+        required: false
+        default: gpt-5.5
+      codex_reasoning_effort:
+        description: Codex reasoning effort (none|low|medium|high|xhigh)
+        type: string
+        required: false
+        default: xhigh
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN:
+      CODEX_AUTH_JSON:
         required: true
-      CLAUDE_REVIEW_GH_TOKEN:
+      CODEX_REVIEW_GH_TOKEN:
         required: true
     outputs:
       decision_found:
-        description: "Whether a valid CLAUDE_REVIEW_DECISION marker was found"
+        description: "Whether a valid CODEX_REVIEW_DECISION marker was found"
         value: ${{ jobs.review.outputs.decision_found }}
       decision:
         description: "Parsed decision value (APPROVE|REQUEST_CHANGES)"
@@ -65,9 +80,9 @@ jobs:
     runs-on: ubicloud-standard-2
     timeout-minutes: 30
     env:
-      # Force AI review actions to use the FINN DevOps PAT so downstream workflows are triggered
-      GITHUB_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-      GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+      # Use the Trips review token so review comments and formal reviews are attributed consistently.
+      GITHUB_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
     outputs:
       decision_found: ${{ steps.set-outputs.outputs.decision_found }}
       decision: ${{ steps.set-outputs.outputs.decision }}
@@ -97,7 +112,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+          token: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
 
       - name: Extract PR number
         id: extract-pr
@@ -270,11 +285,11 @@ jobs:
 
             ## Structured Decision Marker (required)
             At the end of each full review, post EXACTLY one PR comment containing this exact marker block:
-            <!-- CLAUDE_REVIEW_DECISION -->
+            <!-- CODEX_REVIEW_DECISION -->
             DECISION=APPROVE|REQUEST_CHANGES
             BLOCKER=<required when DECISION=REQUEST_CHANGES>
             NEXT_ACTION=<required when DECISION=REQUEST_CHANGES>
-            <!-- /CLAUDE_REVIEW_DECISION -->
+            <!-- /CODEX_REVIEW_DECISION -->
 
             Rules:
             - Always emit DECISION.
@@ -348,37 +363,9 @@ jobs:
           echo "prompt<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FULL_PROMPT" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$FULL_PROMPT" > prompt.txt
 
           echo "✅ Crafted full-review prompt"
-
-      - name: Check track_progress support
-        id: check-track-progress
-        if: |
-          steps.extract-pr.outputs.has_pr == 'true' &&
-          steps.extract-context.outputs.has_review_trigger == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Event: ${{ github.event_name }}, Action: ${{ github.event.action }}"
-
-          case "${{ github.event_name }}" in
-            pull_request)
-              case "${{ github.event.action }}" in
-                ready_for_review)
-                  echo "track_progress=true" >> "$GITHUB_OUTPUT"
-                  echo "✅ track_progress supported for pull_request/${{ github.event.action }}"
-                  ;;
-                *)
-                  echo "track_progress=false" >> "$GITHUB_OUTPUT"
-                  echo "⚠️ track_progress not supported for pull_request/${{ github.event.action }}"
-                  ;;
-              esac
-              ;;
-            *)
-              echo "track_progress=false" >> "$GITHUB_OUTPUT"
-              echo "⚠️ track_progress not supported for ${{ github.event_name }}/${{ github.event.action }}"
-              ;;
-          esac
 
       - name: Capture review start timestamp
         id: review-started-at
@@ -390,40 +377,121 @@ jobs:
           set -euo pipefail
           echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      - name: Run Claude full review
-        id: run-claude
-        uses: anthropics/claude-code-action@v1
-        continue-on-error: true
+      - name: Setup Node
+        uses: actions/setup-node@v4
         if: |
           steps.extract-pr.outputs.has_pr == 'true' &&
           steps.extract-context.outputs.has_review_trigger == 'true'
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-          track_progress: ${{ steps.check-track-progress.outputs.track_progress }}
-          claude_args: |
-            --model opus
-            --allowedTools "mcp__github__add_comment_to_pending_review,
-            mcp__github__add_pull_request_review_comment,
-            mcp__github__create_issue_comment,
-            mcp__github__get_file_contents,
-            mcp__github__get_pull_request_diff,
-            mcp__github_ci__get_ci_status,
-            mcp__github_ci__get_workflow_run_details,
-            mcp__github_ci__download_job_log,
-            mcp__github_comment__update_claude_comment,
-            mcp__github_inline_comment__create_inline_comment,
-            mcp__github_pulls__get_pull_request,
-            mcp__github_pulls__list_pull_request_files,
-            mcp__github_pulls__get_pull_request_diff,
-            Bash,Read,Grep,Glob,WebFetch,WebSearch,TodoWrite"
-          prompt: ${{ steps.craft-prompt.outputs.prompt }}
+          node-version: "22"
 
-      - name: Fallback decision marker when Claude execution crashes
+      - name: Install Codex CLI
+        if: |
+          steps.extract-pr.outputs.has_pr == 'true' &&
+          steps.extract-context.outputs.has_review_trigger == 'true'
+        shell: bash
+        env:
+          PKG_NAME: "@openai/codex"
+          CODEX_VERSION: ${{ inputs.codex_version }}
+        run: |
+          set -euo pipefail
+          version="${CODEX_VERSION:-latest}"
+          if ! printf '%s' "$version" | grep -qE '^(latest|[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$'; then
+            echo "::error::CODEX_VERSION must be 'latest' or strict semver MAJOR.MINOR.PATCH; got: $version" >&2
+            exit 1
+          fi
+          resolved="$(npm view "${PKG_NAME}@${version}" version 2>/dev/null | tail -n1 | tr -d '[:space:]')"
+          if ! printf '%s' "$resolved" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::resolved version is not strict semver: $resolved" >&2
+            exit 1
+          fi
+          echo "Installing ${PKG_NAME}@${resolved} (requested: ${version})"
+          npm_prefix="${RUNNER_TEMP}/npm-global"
+          mkdir -p "$npm_prefix"
+          npm config set prefix "$npm_prefix"
+          export PATH="${npm_prefix}/bin:${PATH}"
+          echo "${npm_prefix}/bin" >> "$GITHUB_PATH"
+          npm install -g --ignore-scripts "${PKG_NAME}@${resolved}"
+          codex --version
+
+      - name: Configure Codex authentication
+        if: |
+          steps.extract-pr.outputs.has_pr == 'true' &&
+          steps.extract-context.outputs.has_review_trigger == 'true'
+        shell: bash
+        env:
+          HOME: ${{ runner.temp }}/codex-home
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CODEX_AUTH_JSON:-}" ]; then
+            echo "Need CODEX_AUTH_JSON to run the Codex code-review workflow." >&2
+            exit 1
+          fi
+          mkdir -p "$HOME/.codex"
+          printf '%s' "$CODEX_AUTH_JSON" > "$HOME/.codex/auth.json"
+          chmod 600 "$HOME/.codex/auth.json"
+          codex login status
+
+      - name: Run Codex full review
+        id: run-codex
+        continue-on-error: true
+        if: |
+          steps.extract-pr.outputs.has_pr == 'true' &&
+          steps.extract-context.outputs.has_review_trigger == 'true'
+        shell: bash
+        env:
+          HOME: ${{ runner.temp }}/codex-home
+          CODEX_MODEL: ${{ inputs.codex_model }}
+          CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort }}
+          GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          prompt_content="$(cat prompt.txt)"
+          set +e
+          codex exec \
+            --model "$CODEX_MODEL" \
+            -c "model_reasoning_effort=\"${CODEX_REASONING_EFFORT}\"" \
+            --dangerously-bypass-approvals-and-sandbox \
+            -o codex-output.txt \
+            "$prompt_content" \
+            > codex-stdout.txt \
+            2> codex-error.txt
+          status=$?
+          set -e
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Codex Full Code Review"
+            echo
+            echo "- PR: #${{ steps.extract-pr.outputs.pr_number }}"
+            echo "- Model: $CODEX_MODEL"
+            echo "- Reasoning effort: $CODEX_REASONING_EFFORT"
+            echo "- Exit code: $status"
+            echo
+            echo '```'
+            if [ -f codex-output.txt ]; then
+              cat codex-output.txt
+            else
+              echo "Codex output file was not created."
+            fi
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$status" -ne 0 ]; then
+            if [ -s codex-error.txt ]; then
+              cat codex-error.txt >&2
+            else
+              echo "Codex exited without stderr." >&2
+            fi
+            exit "$status"
+          fi
+          cat codex-output.txt
+
+      - name: Fallback decision marker when Codex execution crashes
         if: |
           steps.extract-pr.outputs.has_pr == 'true' &&
           steps.extract-context.outputs.has_review_trigger == 'true' &&
-          steps.run-claude.outcome == 'failure'
+          steps.run-codex.outcome == 'failure'
         shell: bash
         run: |
           set -euo pipefail
@@ -431,19 +499,19 @@ jobs:
           PR_NUMBER="${{ steps.extract-pr.outputs.pr_number }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          BLOCKER="Claude full-review execution crashed before emitting a structured decision marker (see run log: ${RUN_URL})."
-          NEXT_ACTION="Re-run /review on this PR after Claude service recovers; if persistent, investigate the failing run logs and workflow inputs."
+          BLOCKER="Codex full-review execution crashed before emitting a structured decision marker (see run log: ${RUN_URL})."
+          NEXT_ACTION="Re-run /review on this PR after Codex auth/service recovers; if persistent, investigate the failing run logs and workflow inputs."
 
           FALLBACK_MARKER=$(printf '%s\n' \
-            "<!-- CLAUDE_REVIEW_DECISION -->" \
+            "<!-- CODEX_REVIEW_DECISION -->" \
             "DECISION=REQUEST_CHANGES" \
             "BLOCKER=${BLOCKER}" \
             "NEXT_ACTION=${NEXT_ACTION}" \
-            "<!-- /CLAUDE_REVIEW_DECISION -->")
+            "<!-- /CODEX_REVIEW_DECISION -->")
 
           gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$FALLBACK_MARKER"
 
-          echo "::warning::Claude action failed; posted fail-closed REQUEST_CHANGES marker so orchestration can continue without a red required check."
+          echo "::warning::Codex CLI failed; posted fail-closed REQUEST_CHANGES marker so orchestration can continue without a red required check."
 
       - name: Parse structured review decision
         id: parse-review-decision
@@ -472,8 +540,8 @@ jobs:
                 .[]
                 | select(.user.login == $automation_login)
                 | select(.created_at >= $run_started_at)
-                | select(.body | contains("<!-- CLAUDE_REVIEW_DECISION -->"))
-                | select(.body | contains("<!-- /CLAUDE_REVIEW_DECISION -->"))
+                | select(.body | contains("<!-- CODEX_REVIEW_DECISION -->"))
+                | select(.body | contains("<!-- /CODEX_REVIEW_DECISION -->"))
               ]
               | sort_by(.created_at)
               | reverse
@@ -491,8 +559,8 @@ jobs:
             COMMENT_BODY=$(printf '%s' "$entry" | base64 -d | jq -r '.body // empty')
 
             MARKER_BLOCK=$(printf '%s\n' "$COMMENT_BODY" | awk '
-              /<!-- CLAUDE_REVIEW_DECISION -->/ {in_block=1; next}
-              /<!-- \/CLAUDE_REVIEW_DECISION -->/ {in_block=0}
+              /<!-- CODEX_REVIEW_DECISION -->/ {in_block=1; next}
+              /<!-- \/CODEX_REVIEW_DECISION -->/ {in_block=0}
               in_block {print}
             ')
 
@@ -536,7 +604,7 @@ jobs:
           if [[ "$DECISION_FOUND" == "true" ]]; then
             echo "✅ Parsed decision marker: ${DECISION}"
           else
-            echo "::error::No valid CLAUDE_REVIEW_DECISION marker found after ${RUN_STARTED_AT}; failing closed (no workflow-submitted review action)."
+            echo "::error::No valid CODEX_REVIEW_DECISION marker found after ${RUN_STARTED_AT}; failing closed (no workflow-submitted review action)."
             exit 1
           fi
 
@@ -606,13 +674,13 @@ jobs:
       total_threads: ${{ steps.thread-counts.outputs.total_threads }}
       unresolved_threads: ${{ steps.thread-counts.outputs.unresolved_threads }}
     env:
-      GITHUB_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-      GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+          token: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
 
       - name: Fetch PR metadata
         id: pr-meta
@@ -821,7 +889,7 @@ jobs:
           PR_NUMBER="${{ steps.pr-meta.outputs.pr_number }}"
 
           TRIGGER_COMMIT_COUNT=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits --paginate \
-            | jq -rs '[.[] | .[] | .commit.message | split("\n")[0] | select(startswith("ci: trigger checks after claude review decision"))] | length')
+            | jq -rs '[.[] | .[] | .commit.message | split("\n")[0] | select(startswith("ci: trigger checks after codex review decision"))] | length')
 
           if [[ "$TRIGGER_COMMIT_COUNT" -gt 0 ]]; then
             echo "already_triggered=true" >> "$GITHUB_OUTPUT"
@@ -854,12 +922,12 @@ jobs:
 
           echo "ℹ️ PR #${{ steps.pr-meta.outputs.pr_number }}: ${{ steps.checks.outputs.trigger_reason }}. Pushing one empty commit to trigger CI."
 
-          git config user.name "Claude PR Assistant"
+          git config user.name "Codex PR Assistant"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin "$HEAD_REF"
           git switch -C "$HEAD_REF" "origin/$HEAD_REF"
-          git commit --allow-empty -m "ci: trigger checks after claude review decision"
+          git commit --allow-empty -m "ci: trigger checks after codex review decision"
           git push origin "HEAD:$HEAD_REF"
 
       - name: Skip workflow-owned APPROVED review for self-authored PR
@@ -883,7 +951,7 @@ jobs:
 
           set +e
           REVIEW_OUTPUT=$(gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve \
-            --body "CI approval: Claude decision APPROVE and unresolved review threads = 0." 2>&1)
+            --body "CI approval: Codex decision APPROVE and unresolved review threads = 0." 2>&1)
           REVIEW_EXIT=$?
           set -e
 

--- a/.github/workflows/code-review-respond.yaml
+++ b/.github/workflows/code-review-respond.yaml
@@ -1,15 +1,31 @@
-# Claude conversational/inline response workflow
+# Codex conversational/inline response workflow
 # Extracted from code-review.yaml for reusable routing
 
 ---
-name: Claude PR Assistant Respond
+name: Codex PR Assistant Respond
 
 on:
   workflow_call:
+    inputs:
+      codex_version:
+        description: Codex CLI version to install (latest or exact semver)
+        type: string
+        required: false
+        default: latest
+      codex_model:
+        description: Codex model to use for direct CLI response
+        type: string
+        required: false
+        default: gpt-5.5
+      codex_reasoning_effort:
+        description: Codex reasoning effort (none|low|medium|high|xhigh)
+        type: string
+        required: false
+        default: xhigh
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN:
+      CODEX_AUTH_JSON:
         required: true
-      CLAUDE_REVIEW_GH_TOKEN:
+      CODEX_REVIEW_GH_TOKEN:
         required: true
 
 permissions:
@@ -23,24 +39,24 @@ jobs:
     runs-on: ubicloud-standard-2
     timeout-minutes: 30
     env:
-      # Force AI review actions to use the FINN DevOps PAT so downstream workflows are triggered
-      GITHUB_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-      GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+      # Use the Trips review token so comments are attributed consistently.
+      GITHUB_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
     if: |
       (
         github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude') &&
+        contains(github.event.comment.body, '@codex') &&
         !startsWith(github.event.comment.body, '/')
       ) ||
       (
         github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude')
+        contains(github.event.comment.body, '@codex')
       )
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
+          token: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
 
       - name: Extract PR number
         id: extract-pr
@@ -153,7 +169,7 @@ jobs:
           echo "  Message preview: ${COMMENT_BODY:0:100}..."
 
       # yamllint disable rule:line-length
-      - name: Craft prompt for Claude
+      - name: Craft prompt for Codex
         id: craft-prompt
         if: steps.extract-pr.outputs.has_pr == 'true'
         shell: bash
@@ -232,30 +248,106 @@ jobs:
           echo "prompt<<EOF" >> $GITHUB_OUTPUT
           echo "$FULL_PROMPT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          printf '%s\n' "$FULL_PROMPT" > prompt.txt
 
           echo "✅ Crafted prompt for comment type: ${{ steps.extract-comment.outputs.comment_type }}"
       # yamllint enable rule:line-length
 
-      - name: Run Claude response
-        uses: anthropics/claude-code-action@v1
+      - name: Setup Node
+        uses: actions/setup-node@v4
         if: steps.extract-pr.outputs.has_pr == 'true'
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-          claude_args: |
-            --model opus
-            --allowedTools "mcp__github__add_comment_to_pending_review,
-            mcp__github__add_pull_request_review_comment,
-            mcp__github__create_issue_comment,
-            mcp__github__get_file_contents,
-            mcp__github__get_pull_request_diff,
-            mcp__github_ci__get_ci_status,
-            mcp__github_ci__get_workflow_run_details,
-            mcp__github_ci__download_job_log,
-            mcp__github_comment__update_claude_comment,
-            mcp__github_inline_comment__create_inline_comment,
-            mcp__github_pulls__get_pull_request,
-            mcp__github_pulls__list_pull_request_files,
-            mcp__github_pulls__get_pull_request_diff,
-            Bash,Read,Grep,Glob,WebFetch,WebSearch,TodoWrite"
-          prompt: ${{ steps.craft-prompt.outputs.prompt }}
+          node-version: "22"
+
+      - name: Install Codex CLI
+        if: steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        env:
+          PKG_NAME: "@openai/codex"
+          CODEX_VERSION: ${{ inputs.codex_version }}
+        run: |
+          set -euo pipefail
+          version="${CODEX_VERSION:-latest}"
+          if ! printf '%s' "$version" | grep -qE '^(latest|[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$'; then
+            echo "::error::CODEX_VERSION must be 'latest' or strict semver MAJOR.MINOR.PATCH; got: $version" >&2
+            exit 1
+          fi
+          resolved="$(npm view "${PKG_NAME}@${version}" version 2>/dev/null | tail -n1 | tr -d '[:space:]')"
+          if ! printf '%s' "$resolved" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::resolved version is not strict semver: $resolved" >&2
+            exit 1
+          fi
+          echo "Installing ${PKG_NAME}@${resolved} (requested: ${version})"
+          npm_prefix="${RUNNER_TEMP}/npm-global"
+          mkdir -p "$npm_prefix"
+          npm config set prefix "$npm_prefix"
+          export PATH="${npm_prefix}/bin:${PATH}"
+          echo "${npm_prefix}/bin" >> "$GITHUB_PATH"
+          npm install -g --ignore-scripts "${PKG_NAME}@${resolved}"
+          codex --version
+
+      - name: Configure Codex authentication
+        if: steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        env:
+          HOME: ${{ runner.temp }}/codex-home
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CODEX_AUTH_JSON:-}" ]; then
+            echo "Need CODEX_AUTH_JSON to run the Codex response workflow." >&2
+            exit 1
+          fi
+          mkdir -p "$HOME/.codex"
+          printf '%s' "$CODEX_AUTH_JSON" > "$HOME/.codex/auth.json"
+          chmod 600 "$HOME/.codex/auth.json"
+          codex login status
+
+      - name: Run Codex response
+        if: steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        env:
+          HOME: ${{ runner.temp }}/codex-home
+          CODEX_MODEL: ${{ inputs.codex_model }}
+          CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort }}
+          GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          prompt_content="$(cat prompt.txt)"
+          set +e
+          codex exec \
+            --model "$CODEX_MODEL" \
+            -c "model_reasoning_effort=\"${CODEX_REASONING_EFFORT}\"" \
+            --dangerously-bypass-approvals-and-sandbox \
+            -o codex-output.txt \
+            "$prompt_content" \
+            > codex-stdout.txt \
+            2> codex-error.txt
+          status=$?
+          set -e
+          {
+            echo "## Codex PR Response"
+            echo
+            echo "- PR: #${{ steps.extract-pr.outputs.pr_number }}"
+            echo "- Model: $CODEX_MODEL"
+            echo "- Reasoning effort: $CODEX_REASONING_EFFORT"
+            echo "- Exit code: $status"
+            echo
+            echo '```'
+            if [ -f codex-output.txt ]; then
+              cat codex-output.txt
+            else
+              echo "Codex output file was not created."
+            fi
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$status" -ne 0 ]; then
+            if [ -s codex-error.txt ]; then
+              cat codex-error.txt >&2
+            else
+              echo "Codex exited without stderr." >&2
+            fi
+            exit "$status"
+          fi
+          cat codex-output.txt

--- a/.github/workflows/code-review-welcome.yaml
+++ b/.github/workflows/code-review-welcome.yaml
@@ -1,4 +1,4 @@
-# Claude Code Review Welcome Workflow
+# Codex Code Review Welcome Workflow
 # Extracted from code-review.yaml for reusable welcome-comment behavior
 
 ---
@@ -31,7 +31,7 @@ jobs:
         run: |
           # Check if we already posted a welcome message
           WELCOME_EXISTS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq '[.[] | select(.body | (contains("🤖 **Claude PR Assistant**") or contains("🤖 **Code Review Assistant**")))] | length')
+            --jq '[.[] | select(.body | (contains("🤖 **Codex PR Assistant**") or contains("🤖 **Code Review Assistant**")))] | length')
 
           if [[ "$WELCOME_EXISTS" -gt 0 ]]; then
             echo "found=true" >> $GITHUB_OUTPUT
@@ -46,15 +46,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "$(cat <<'EOF'
-          🤖 **Claude PR Assistant**
+          🤖 **Codex PR Assistant**
 
-          Welcome! This PR has access to AI-powered assistant support using **Claude Opus**.
+          Welcome! This PR has access to AI-powered assistant support using **Codex CLI**.
 
           **How to trigger:**
           - 🚀 Open/reopen PRs (including draft PRs)
           - 🧭 Comment `/review` (optionally add extra instructions after it)
-          - 💬 Tag `@claude` in any comment
-          - 📝 Reply to inline code comments with `@claude`
+          - 💬 Tag `@codex` in any comment
+          - 📝 Reply to inline code comments with `@codex`
 
           **What I can help with:**
           - Comprehensive review feedback (security, performance, best practices)

--- a/docs/review-workflow-validation-matrix.md
+++ b/docs/review-workflow-validation-matrix.md
@@ -9,11 +9,11 @@
 ## Decision Marker Schema (reference)
 
 ```text
-<!-- CLAUDE_REVIEW_DECISION -->
+<!-- CODEX_REVIEW_DECISION -->
 DECISION=APPROVE|REQUEST_CHANGES
 BLOCKER=<required when REQUEST_CHANGES>
 NEXT_ACTION=<required when REQUEST_CHANGES>
-<!-- /CLAUDE_REVIEW_DECISION -->
+<!-- /CODEX_REVIEW_DECISION -->
 ```
 
 Parser rules:
@@ -31,7 +31,7 @@ Parser rules:
 - **Trigger/event**: `pull_request` (opened | reopened | synchronize | review_requested) or `/review` slash command
 - **Preconditions**:
   - PR exists, not draft (or draft with UC-02).
-  - Claude posts valid `DECISION=APPROVE` marker.
+  - Codex posts valid `DECISION=APPROVE` marker.
   - All review threads resolved (unresolved = 0).
 - **Expected decision path**: `parse-review-decision` → `decision_found=true`, `decision=APPROVE`
 - **Expected workflow actions**:
@@ -43,7 +43,7 @@ Parser rules:
 - **Evidence to capture**:
   - Workflow run URL (both `review` and `review-orchestration` jobs green).
   - PR review list: `gh pr reviews <PR> --json author,state` shows `APPROVED` from automation user.
-  - PR comment containing `<!-- CLAUDE_REVIEW_DECISION -->` with `DECISION=APPROVE`.
+  - PR comment containing `<!-- CODEX_REVIEW_DECISION -->` with `DECISION=APPROVE`.
   - `review-orchestration` job log line: `✅ Approval precondition satisfied: unresolved_threads=0`.
 
 #### Validation Playbook
@@ -62,7 +62,7 @@ gh run list --repo "$REPO" --branch "$(gh pr view $PR_NUMBER --repo $REPO --json
 
 # 3. Assert: decision marker exists
 gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-  | jq '[.[] | select(.body | contains("CLAUDE_REVIEW_DECISION")) | select(.body | contains("DECISION=APPROVE"))] | length'
+  | jq '[.[] | select(.body | contains("CODEX_REVIEW_DECISION")) | select(.body | contains("DECISION=APPROVE"))] | length'
 # PASS: >= 1
 
 # 4. Assert: workflow-submitted APPROVED review
@@ -88,7 +88,7 @@ gh run view "$RUN_ID" --repo "$REPO" --json jobs \
 - **Trigger/event**: `/review` slash command on a draft PR
 - **Preconditions**:
   - PR is in draft state (`gh pr view --json isDraft` → `true`).
-  - Claude posts valid `DECISION=APPROVE` marker.
+  - Codex posts valid `DECISION=APPROVE` marker.
   - All review threads resolved.
 - **Expected decision path**: Same as UC-01.
 - **Expected workflow actions**:
@@ -132,7 +132,7 @@ gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft -q '.isDraft'
 
 - **Trigger/event**: `pull_request` event or `/review` slash command
 - **Preconditions**:
-  - Claude posts valid `DECISION=REQUEST_CHANGES` marker with both `BLOCKER` and `NEXT_ACTION`.
+  - Codex posts valid `DECISION=REQUEST_CHANGES` marker with both `BLOCKER` and `NEXT_ACTION`.
 - **Expected decision path**: `parse-review-decision` → `decision_found=true`, `decision=REQUEST_CHANGES`, `blocker` and `next_action` populated.
 - **Expected workflow actions**:
   1. `review-orchestration` job runs.
@@ -178,7 +178,7 @@ gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - Claude posts valid `DECISION=APPROVE` marker.
+  - Codex posts valid `DECISION=APPROVE` marker.
   - At least 1 unresolved review thread exists on the PR.
 - **Expected decision path**: `decision_found=true`, `decision=APPROVE`.
 - **Expected workflow actions**:
@@ -203,11 +203,11 @@ PR_NUMBER=<test-pr-with-unresolved-thread>
 # (manually leave a review comment unresolved, or create one via API)
 
 # Simulate: post APPROVE marker as automation user
-# (In real flow, Claude would post this; for testing, force-post the marker)
+# (In real flow, Codex would post this; for testing, force-post the marker)
 AUTOMATION_USER=$(gh api user --jq '.login')
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CLAUDE_REVIEW_DECISION -->
+gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=APPROVE
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 
 # Trigger review or let the existing run proceed
 
@@ -236,7 +236,7 @@ gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "DECISION=APPROVE requ
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - Claude completes review but does NOT post a `<!-- CLAUDE_REVIEW_DECISION -->` marker.
+  - Codex completes review but does NOT post a `<!-- CODEX_REVIEW_DECISION -->` marker.
 - **Expected decision path**: `parse-review-decision` → `decision_found=false`.
 - **Expected workflow actions**:
   1. `review` job completes with `decision_found=false`.
@@ -246,7 +246,7 @@ gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "DECISION=APPROVE requ
 - **Evidence to capture**:
   - `review` job output: `decision_found=false`.
   - `review-orchestration` job status: `skipped`.
-  - Warning annotation: `No valid CLAUDE_REVIEW_DECISION marker found`.
+  - Warning annotation: `No valid CODEX_REVIEW_DECISION marker found`.
 
 #### Validation Playbook
 
@@ -254,8 +254,8 @@ gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "DECISION=APPROVE requ
 REPO="jai/trips-frontend"
 PR_NUMBER=<test-pr>
 
-# Scenario: Claude ran but didn't post marker
-# (This would need a test where Claude's prompt is modified, or marker is manually deleted after run)
+# Scenario: Codex ran but didn't post marker
+# (This would need a test where Codex's prompt is modified, or marker is manually deleted after run)
 
 # Assert: review job outputs
 RUN_ID=$(gh run list --repo "$REPO" --workflow "code-review.yaml" --limit 1 --json databaseId -q '.[0].databaseId')
@@ -266,7 +266,7 @@ gh run view "$RUN_ID" --repo "$REPO" --json jobs \
 # PASS: conclusion == "skipped" or conclusion == null (job didn't run)
 
 # Check warning in logs
-gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "No valid CLAUDE_REVIEW_DECISION marker found"
+gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "No valid CODEX_REVIEW_DECISION marker found"
 # PASS: >= 1
 ```
 
@@ -278,7 +278,7 @@ gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "No valid CLAUDE_REVIE
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - Claude posts a marker block with `DECISION=LGTM` (or any value other than `APPROVE`/`REQUEST_CHANGES`).
+  - Codex posts a marker block with `DECISION=LGTM` (or any value other than `APPROVE`/`REQUEST_CHANGES`).
 - **Expected decision path**: Parser's `case` statement falls through to `*)`; marker is not valid → `decision_found=false`.
 - **Expected workflow actions**: Same as UC-05 — orchestration skipped.
 - **Expected PR outcome**: No review state change.
@@ -288,9 +288,9 @@ gh run view "$RUN_ID" --repo "$REPO" --log 2>&1 | grep -c "No valid CLAUDE_REVIE
 
 ```bash
 # Simulate: post marker with invalid decision
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CLAUDE_REVIEW_DECISION -->
+gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=LGTM
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 
 # Then trigger review and verify same assertions as UC-05
 ```
@@ -303,7 +303,7 @@ DECISION=LGTM
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - Claude posts marker: `DECISION=REQUEST_CHANGES` but omits `BLOCKER=`.
+  - Codex posts marker: `DECISION=REQUEST_CHANGES` but omits `BLOCKER=`.
 - **Expected decision path**: Parser requires both `BLOCKER` and `NEXT_ACTION` for `REQUEST_CHANGES` to be valid. Missing `BLOCKER` → marker invalid → `decision_found=false`.
 - **Expected workflow actions**: Same as UC-05 — orchestration skipped.
 - **Expected PR outcome**: No review state change.
@@ -312,10 +312,10 @@ DECISION=LGTM
 
 ```bash
 # Simulate: REQUEST_CHANGES without BLOCKER
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CLAUDE_REVIEW_DECISION -->
+gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=REQUEST_CHANGES
 NEXT_ACTION=Fix the tests
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 
 # Assertions same as UC-05
 ```
@@ -328,7 +328,7 @@ NEXT_ACTION=Fix the tests
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - Claude posts marker: `DECISION=REQUEST_CHANGES` with `BLOCKER=` but omits `NEXT_ACTION=`.
+  - Codex posts marker: `DECISION=REQUEST_CHANGES` with `BLOCKER=` but omits `NEXT_ACTION=`.
 - **Expected decision path**: Same as UC-07 — marker invalid → `decision_found=false`.
 - **Expected workflow actions**: Same as UC-05.
 
@@ -336,10 +336,10 @@ NEXT_ACTION=Fix the tests
 
 ```bash
 # Simulate: REQUEST_CHANGES without NEXT_ACTION
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CLAUDE_REVIEW_DECISION -->
+gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=REQUEST_CHANGES
 BLOCKER=Merge conflict
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 
 # Assertions same as UC-05
 ```
@@ -348,23 +348,20 @@ BLOCKER=Merge conflict
 
 ---
 
-### UC-09 · Conversational @claude cannot approve/request-changes (respond workflow)
+### UC-09 · Conversational @codex cannot approve/request-changes (respond workflow)
 
-- **Trigger/event**: `issue_comment` containing `@claude` (not `/review`) OR `pull_request_review_comment` containing `@claude`
+- **Trigger/event**: `issue_comment` containing `@codex` (not `/review`) OR `pull_request_review_comment` containing `@codex`
 - **Preconditions**:
-  - Comment contains `@claude` but does NOT start with `/`.
+  - Comment contains `@codex` but does NOT start with `/`.
   - Respond workflow runs (not full-review workflow).
 - **Expected decision path**: No decision parsing occurs (respond workflow has no `parse-review-decision` step).
 - **Expected workflow actions**:
   1. `respond` job runs with conversational prompt.
   2. Prompt contains `CONVERSATIONAL-ONLY RULE (MANDATORY)`.
-  3. `allowedTools` excludes:
-     - `mcp__github__create_pending_pull_request_review`
-     - `mcp__github__submit_pending_pull_request_review`
-  4. Claude can only post conversational comments.
+  3. Prompt forbids `gh pr review --approve` and `gh pr review --request-changes`.
+  4. Codex can only post conversational comments.
 - **Expected PR outcome**: No review state change. Only conversational reply posted.
 - **Evidence to capture**:
-  - Workflow YAML inspection: `allowedTools` in respond workflow does NOT contain `create_pending_pull_request_review` or `submit_pending_pull_request_review`.
   - Prompt text contains `Never approve a PR and never request changes`.
   - No new `APPROVED` or `CHANGES_REQUESTED` reviews from automation user.
 
@@ -374,16 +371,16 @@ BLOCKER=Merge conflict
 REPO="jai/trips-frontend"
 PR_NUMBER=<test-pr>
 
-# 1. Post conversational @claude comment
-gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@claude Can you explain the approach here?"
+# 1. Post conversational @codex comment
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex Can you explain the approach here?"
 
 # 2. Wait for respond workflow to complete
 RUN_ID=$(gh run list --repo "$REPO" --workflow "code-review.yaml" --limit 1 --json databaseId -q '.[0].databaseId')
 
-# 3. Static check: verify allowedTools in code-review-respond.yaml
-grep -c "create_pending_pull_request_review\|submit_pending_pull_request_review" \
+# 3. Static check: verify the respond prompt forbids formal review state changes
+grep -c "Never approve a PR and never request changes" \
   .github/workflows/code-review-respond.yaml
-# PASS: 0 (not present)
+# PASS: >= 1
 
 # 4. Assert: no new review state changes from automation user
 REVIEWS_BEFORE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate | jq 'length')
@@ -408,7 +405,7 @@ gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
   - Comment is on a PR (not a plain issue).
   - Comment body starts with `/review` (with optional args after).
 - **Expected decision path**: `extract-context` → `context_type=slash_review`, `trigger_desc=/review slash command`.
-- **Expected workflow actions**: Full review runs; same decision flow as UC-01/UC-03 depending on Claude's decision.
+- **Expected workflow actions**: Full review runs; same decision flow as UC-01/UC-03 depending on Codex's decision.
 - **Expected PR outcome**: Full review with decision marker posted.
 - **Evidence to capture**:
   - `review` job log: `context_type=slash_review`.
@@ -468,7 +465,7 @@ gh run view "$RUN_ID" --repo "$REPO" --json jobs | jq '.jobs[] | {name, conclusi
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - Claude posts TWO valid marker comments during the same run window (both after `started_at`, both from automation user).
+  - Codex posts TWO valid marker comments during the same run window (both after `started_at`, both from automation user).
   - First: `DECISION=REQUEST_CHANGES` (with blocker/next_action).
   - Second (later timestamp): `DECISION=APPROVE`.
 - **Expected decision path**: Parser sorts by `created_at` descending, picks first valid → `DECISION=APPROVE`.
@@ -481,17 +478,17 @@ gh run view "$RUN_ID" --repo "$REPO" --json jobs | jq '.jobs[] | {name, conclusi
 
 ```bash
 # Simulate: post two markers as automation user in sequence
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CLAUDE_REVIEW_DECISION -->
+gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=REQUEST_CHANGES
 BLOCKER=test blocker
 NEXT_ACTION=test action
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 
 sleep 2
 
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CLAUDE_REVIEW_DECISION -->
+gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=APPROVE
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 
 # Trigger and verify APPROVE is the acted-upon decision
 ```
@@ -502,7 +499,7 @@ DECISION=APPROVE
 
 - **Trigger/event**: Any full-review trigger
 - **Preconditions**:
-  - A human user (not the automation actor) posts a comment containing a valid `CLAUDE_REVIEW_DECISION` marker.
+  - A human user (not the automation actor) posts a comment containing a valid `CODEX_REVIEW_DECISION` marker.
   - No marker from the automation user exists.
 - **Expected decision path**: Parser filters by `automation_login` → no candidates → `decision_found=false`.
 - **Expected workflow actions**: Same as UC-05 — orchestration skipped.
@@ -511,9 +508,9 @@ DECISION=APPROVE
 
 ```bash
 # As a regular user (not the GH App / PAT user), post:
-# <!-- CLAUDE_REVIEW_DECISION -->
+# <!-- CODEX_REVIEW_DECISION -->
 # DECISION=APPROVE
-# <!-- /CLAUDE_REVIEW_DECISION -->
+# <!-- /CODEX_REVIEW_DECISION -->
 
 # Then trigger review and verify decision_found=false (same as UC-05)
 ```
@@ -540,7 +537,7 @@ DECISION=APPROVE
 - **Expected workflow actions**:
   1. `checks` step: `should_trigger=true`.
   2. `duplicate-commit` step: `already_triggered=false`.
-  3. Empty commit pushed: `ci: trigger checks after claude review decision`.
+  3. Empty commit pushed: `ci: trigger checks after codex review decision`.
   4. Approval submitted.
 - **Evidence to capture**:
   - Commit history includes empty commit with expected message.
@@ -600,7 +597,7 @@ grep -c "create_pending_pull_request_review\|submit_pending_pull_request_review"
 - **UC-06**: ❌ Invalid decision value → fail closed (negative)
 - **UC-07**: ❌ REQUEST_CHANGES without BLOCKER → fail closed (negative)
 - **UC-08**: ❌ REQUEST_CHANGES without NEXT_ACTION → fail closed (negative)
-- **UC-09**: 🔒 Conversational @claude cannot approve/request-changes
+- **UC-09**: 🔒 Conversational @codex cannot approve/request-changes
 - **UC-10**: ✅ `/review` slash command trigger
 - **UC-11**: ✅ PR event triggers (opened/reopened/synchronize/ready_for_review/review_requested)
 - **UC-12**: ✅ Multiple markers → latest valid wins
@@ -635,11 +632,11 @@ For negative-path tests (UC-04 through UC-08), manual marker injection may be ne
 ```bash
 # Post a decision marker as the automation user
 gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-  -f body='<!-- CLAUDE_REVIEW_DECISION -->
+  -f body='<!-- CODEX_REVIEW_DECISION -->
 DECISION=<value>
 BLOCKER=<if needed>
 NEXT_ACTION=<if needed>
-<!-- /CLAUDE_REVIEW_DECISION -->'
+<!-- /CODEX_REVIEW_DECISION -->'
 ```
 
 For UC-04 specifically, create an unresolved review thread:


### PR DESCRIPTION
## What
- Convert the reusable Trips code-review workflows from Claude Code to Codex CLI.
- Update the welcome/respond/full-review workflow text, trigger handle, marker parsing, and validation docs for Codex.

## Why
Trips repos now standardize LLM review automation on Codex instead of Claude. Caller repo branches depend on this reusable workflow landing on `main` first.

## How to test
- `actionlint -shellcheck= -ignore 'label "ubicloud-standard-2" is unknown' .github/workflows/code-review-full.yaml .github/workflows/code-review-respond.yaml .github/workflows/code-review-welcome.yaml`\n- `npm view @openai/codex version`\n