### PR TITLE
ci: centralize Trips code review router

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -1,0 +1,105 @@
+---
+name: Codex PR Assistant
+
+on:
+  workflow_call:
+    inputs:
+      custom_review_instructions:
+        description: Optional additional review instructions prepended to the default review prompt.
+        type: string
+        required: false
+        default: ""
+      codex_version:
+        description: Codex CLI version to install (latest or exact semver).
+        type: string
+        required: false
+        default: latest
+      codex_model:
+        description: Codex model to use for direct CLI review and responses.
+        type: string
+        required: false
+        default: gpt-5.5
+      codex_reasoning_effort:
+        description: Codex reasoning effort (none|low|medium|high|xhigh).
+        type: string
+        required: false
+        default: xhigh
+    secrets:
+      CODEX_AUTH_JSON:
+        required: true
+      CODEX_REVIEW_GH_TOKEN:
+        required: true
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  welcome:
+    name: Welcome comment
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      (github.event.action == 'opened' || github.event.action == 'reopened')
+    uses: ./.github/workflows/code-review-welcome.yaml
+    secrets:
+      GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+
+  full-review:
+    name: Full code review
+    if: >-
+      (
+        github.event_name == 'pull_request' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'ready_for_review' ||
+          github.event.action == 'synchronize' ||
+          github.event.action == 'review_requested'
+        )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        startsWith(github.event.comment.body, '/review')
+      )
+    uses: ./.github/workflows/code-review-full.yaml
+    with:
+      custom_review_instructions: ${{ inputs.custom_review_instructions }}
+      codex_version: ${{ inputs.codex_version }}
+      codex_model: ${{ inputs.codex_model }}
+      codex_reasoning_effort: ${{ inputs.codex_reasoning_effort }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      CODEX_REVIEW_GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+
+  respond:
+    name: Conversational @codex response
+    if: >-
+      github.event.comment.user.login != 'jai-bot-reviewer' &&
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(github.event.comment.body, '@codex') &&
+          !startsWith(github.event.comment.body, '/')
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+          contains(github.event.comment.body, '@codex')
+        )
+      )
+    uses: ./.github/workflows/code-review-respond.yaml
+    with:
+      codex_version: ${{ inputs.codex_version }}
+      codex_model: ${{ inputs.codex_model }}
+      codex_reasoning_effort: ${{ inputs.codex_reasoning_effort }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      CODEX_REVIEW_GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -1,0 +1,40 @@
+---
+name: Validate Workflows
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "scripts/**"
+      - "templates/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/**"
+      - "templates/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+
+      - name: Install validation tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Validate workflow library
+        shell: bash
+        run: scripts/validate-workflows.sh

--- a/scripts/generate-caller-workflows.sh
+++ b/scripts/generate-caller-workflows.sh
@@ -1,102 +1,46 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_DIR="/root/Developer/trips"
-DEFAULT_REPOS=(trips api frontend worker infra fastlane)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$REPO_ROOT/templates/code-review-caller.yaml"
+
+DEFAULT_TARGETS=(
+  "/Users/jai/Developer/trips"
+  "/Users/jai/Developer/trips/api"
+  "/Users/jai/Developer/trips/frontend"
+  "/Users/jai/Developer/trips/worker"
+  "/Users/jai/Developer/trips/infra"
+  "/Users/jai/Developer/trips-fastlane"
+)
+
+mode="write"
+if [[ "${1:-}" == "--check" ]]; then
+  mode="check"
+  shift
+fi
 
 if [[ "$#" -gt 0 ]]; then
   TARGETS=("$@")
 else
-  TARGETS=("${DEFAULT_REPOS[@]}")
+  TARGETS=("${DEFAULT_TARGETS[@]}")
 fi
 
 for target in "${TARGETS[@]}"; do
-  if [[ "$target" = /* ]]; then
-    repo_dir="$target"
-  else
-    repo_dir="$BASE_DIR/$target"
-  fi
-
+  repo_dir="$target"
   workflow_path="$repo_dir/.github/workflows/code-review.yaml"
-  mkdir -p "$(dirname "$workflow_path")"
 
-  cat > "$workflow_path" <<'YAML'
-name: Claude PR Assistant
-
-on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request:
-    types: [opened, reopened, ready_for_review, review_requested, synchronize]
-
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  actions: read
-
-concurrency:
-  group: code-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false
-
-jobs:
-  welcome:
-    name: Welcome comment
-    if: >-
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' || github.event.action == 'reopened')
-    uses: jai/trips-ci/.github/workflows/code-review-welcome.yaml@main
-    secrets:
-      GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-
-  full-review:
-    name: Full code review
-    if: >-
-      (
-        github.event_name == 'pull_request' &&
-        (
-          github.event.action == 'opened' ||
-          github.event.action == 'reopened' ||
-          github.event.action == 'ready_for_review' ||
-          github.event.action == 'synchronize' ||
-          github.event.action == 'review_requested'
-        )
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/review')
-      )
-    uses: jai/trips-ci/.github/workflows/code-review-full.yaml@main
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      CLAUDE_REVIEW_GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-
-  respond:
-    name: Conversational @claude response
-    if: >-
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude') &&
-        !startsWith(github.event.comment.body, '/')
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude')
-      )
-    uses: jai/trips-ci/.github/workflows/code-review-respond.yaml@main
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      CLAUDE_REVIEW_GH_TOKEN: ${{ secrets.CLAUDE_REVIEW_GH_TOKEN }}
-YAML
-
-  echo "Wrote: $workflow_path"
-  cat "$workflow_path"
-  echo
-  echo "---"
-  echo
+  if [[ "$mode" == "check" ]]; then
+    if ! cmp -s "$TEMPLATE" "$workflow_path"; then
+      echo "Out of date: $workflow_path" >&2
+      diff -u "$TEMPLATE" "$workflow_path" || true
+      exit 1
+    fi
+    echo "Current: $workflow_path"
+  else
+    mkdir -p "$(dirname "$workflow_path")"
+    cp "$TEMPLATE" "$workflow_path"
+    echo "Wrote: $workflow_path"
+  fi
 
 done

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$repo_root/tmp/workflow-validation"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir/.github/workflows"
+cp "$repo_root/templates/code-review-caller.yaml" "$tmp_dir/.github/workflows/code-review.yaml"
+
+actionlint_args=(
+  -shellcheck=
+  -ignore 'label "ubicloud-standard-2" is unknown'
+)
+
+actionlint "${actionlint_args[@]}" "$repo_root"/.github/workflows/*.yaml
+actionlint "${actionlint_args[@]}" "$tmp_dir/.github/workflows/code-review.yaml"
+shellcheck "$repo_root/scripts/generate-caller-workflows.sh" "$repo_root/scripts/validate-workflows.sh"
+
+if rg -n 'Claude PR Assistant|@claude|CLAUDE_' \
+  "$repo_root/.github/workflows" \
+  "$repo_root/templates" \
+  "$repo_root/scripts/generate-caller-workflows.sh"; then
+  echo "Found stale Claude code-review references." >&2
+  exit 1
+fi
+
+echo "Workflow validation passed."

--- a/templates/code-review-caller.yaml
+++ b/templates/code-review-caller.yaml
@@ -1,0 +1,28 @@
+---
+name: Codex PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, ready_for_review, review_requested, synchronize]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: code-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  codex-review:
+    name: Codex review router
+    uses: jai/trips-ci/.github/workflows/code-review.yaml@main
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      CODEX_REVIEW_GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a reusable top-level Codex review router in trips-ci
- Add a canonical thin caller workflow template
- Add workflow validation for reusable workflows, the caller template, and stale Claude references

## Validation
- scripts/validate-workflows.sh