### PR TITLE
ci: preserve fastlane review trigger gate

### DIFF
--- a/.github/workflows/pr-image-check.yaml
+++ b/.github/workflows/pr-image-check.yaml
@@ -1,0 +1,65 @@
+---
+name: PR Image Check
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-images:
+    name: Validate PR Images
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Check PR markdown image URLs
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          body_file="$(mktemp)"
+          gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" \
+            --jq '.body // ""' \
+            > "$body_file"
+
+          urls_file="$(mktemp)"
+          grep -oE '!\[[^]]*\]\([^)]+' "$body_file" \
+            | sed -E 's/^!\[[^]]*\]\(//; s/[[:space:]].*$//; s/^<//; s/>$//' \
+            | sort -u \
+            > "$urls_file" || true
+
+          if [[ ! -s "$urls_file" ]]; then
+            echo "No markdown image URLs found."
+            exit 0
+          fi
+
+          failed=0
+          while IFS= read -r url; do
+            if [[ "$url" != http://* && "$url" != https://* ]]; then
+              echo "Skipping non-HTTP image URL: $url"
+              continue
+            fi
+
+            status="$(
+              curl --location --silent --show-error --output /dev/null \
+                --write-out '%{http_code}' \
+                --max-time 20 \
+                "$url" || true
+            )"
+
+            if [[ ! "$status" =~ ^[0-9]{3}$ || "$status" -ge 400 ]]; then
+              echo "Image URL failed with HTTP $status: $url"
+              failed=1
+            else
+              echo "Image URL OK with HTTP $status: $url"
+            fi
+          done < "$urls_file"
+
+          exit "$failed"

--- a/scripts/generate-caller-workflows.sh
+++ b/scripts/generate-caller-workflows.sh
@@ -15,10 +15,16 @@ DEFAULT_TARGETS=(
 )
 
 mode="write"
-if [[ "${1:-}" == "--check" ]]; then
-  mode="check"
-  shift
-fi
+case "${1:-}" in
+  --check)
+    mode="check"
+    shift
+    ;;
+  --stdout)
+    mode="stdout"
+    shift
+    ;;
+esac
 
 if [[ "$#" -gt 0 ]]; then
   TARGETS=("$@")
@@ -26,20 +32,68 @@ else
   TARGETS=("${DEFAULT_TARGETS[@]}")
 fi
 
+is_jai_only_target() {
+  local target_name
+  target_name="$(basename "$1")"
+  [[ "$target_name" == "trips-fastlane" || "$target_name" == trips-fastlane-* || "$target_name" == "fastlane" ]]
+}
+
+render_workflow() {
+  local target="$1"
+
+  if ! is_jai_only_target "$target"; then
+    cat "$TEMPLATE"
+    return
+  fi
+
+  awk '
+    {
+      print
+      if ($0 == "    name: Codex review router") {
+        print "    if: >-"
+        print "      ("
+        print "        github.event_name == '\''pull_request'\'' &&"
+        print "        github.event.pull_request.user.login == '\''jai'\''"
+        print "      ) ||"
+        print "      ("
+        print "        github.event_name == '\''issue_comment'\'' &&"
+        print "        github.event.issue.pull_request &&"
+        print "        github.event.issue.user.login == '\''jai'\'' &&"
+        print "        github.event.comment.user.login == '\''jai'\''"
+        print "      ) ||"
+        print "      ("
+        print "        github.event_name == '\''pull_request_review_comment'\'' &&"
+        print "        github.event.pull_request.user.login == '\''jai'\'' &&"
+        print "        github.event.comment.user.login == '\''jai'\''"
+        print "      )"
+      }
+    }
+  ' "$TEMPLATE"
+}
+
+if [[ "$mode" == "stdout" ]]; then
+  if [[ "${#TARGETS[@]}" -ne 1 ]]; then
+    echo "--stdout expects exactly one target" >&2
+    exit 2
+  fi
+  render_workflow "${TARGETS[0]}"
+  exit 0
+fi
+
 for target in "${TARGETS[@]}"; do
   repo_dir="$target"
   workflow_path="$repo_dir/.github/workflows/code-review.yaml"
 
   if [[ "$mode" == "check" ]]; then
-    if ! cmp -s "$TEMPLATE" "$workflow_path"; then
+    if ! cmp -s <(render_workflow "$repo_dir") "$workflow_path"; then
       echo "Out of date: $workflow_path" >&2
-      diff -u "$TEMPLATE" "$workflow_path" || true
+      diff -u <(render_workflow "$repo_dir") "$workflow_path" || true
       exit 1
     fi
     echo "Current: $workflow_path"
   else
     mkdir -p "$(dirname "$workflow_path")"
-    cp "$TEMPLATE" "$workflow_path"
+    render_workflow "$repo_dir" > "$workflow_path"
     echo "Wrote: $workflow_path"
   fi
 

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -11,7 +11,12 @@ trap cleanup EXIT
 
 rm -rf "$tmp_dir"
 mkdir -p "$tmp_dir/.github/workflows"
-cp "$repo_root/templates/code-review-caller.yaml" "$tmp_dir/.github/workflows/code-review.yaml"
+"$repo_root/scripts/generate-caller-workflows.sh" --stdout \
+  /Users/jai/Developer/trips \
+  > "$tmp_dir/.github/workflows/code-review.yaml"
+"$repo_root/scripts/generate-caller-workflows.sh" --stdout \
+  /Users/jai/Developer/trips-fastlane \
+  > "$tmp_dir/.github/workflows/code-review-fastlane.yaml"
 
 actionlint_args=(
   -shellcheck=
@@ -19,7 +24,7 @@ actionlint_args=(
 )
 
 actionlint "${actionlint_args[@]}" "$repo_root"/.github/workflows/*.yaml
-actionlint "${actionlint_args[@]}" "$tmp_dir/.github/workflows/code-review.yaml"
+actionlint "${actionlint_args[@]}" "$tmp_dir/.github/workflows"/*.yaml
 shellcheck "$repo_root/scripts/generate-caller-workflows.sh" "$repo_root/scripts/validate-workflows.sh"
 
 if rg -n 'Claude PR Assistant|@claude|CLAUDE_' \


### PR DESCRIPTION
## Summary
- teach the caller workflow generator about the `trips-fastlane` Jai-only review trigger gate
- validate both the standard caller wrapper and the fastlane guarded wrapper with actionlint
- add the missing reusable `pr-image-check.yaml` workflow consumed by frontend screenshot checks

## Validation
- `scripts/validate-workflows.sh`
- `scripts/generate-caller-workflows.sh --check /Users/jai/Developer/worktrees/trips-centralize-review /Users/jai/Developer/worktrees/trips-api-centralize-review /Users/jai/Developer/worktrees/trips-frontend-centralize-review /Users/jai/Developer/worktrees/trips-worker-centralize-review /Users/jai/Developer/worktrees/trips-infra-centralize-review /Users/jai/Developer/worktrees/trips-fastlane-centralize-review`
- `actionlint -shellcheck= -ignore 'label "ubicloud-standard-2" is unknown' .github/workflows/pr-image-check.yaml`\n- `git diff --check`