### PR TITLE
ci: rerun issue flow gate on label changes

### DIFF
--- a/.github/workflows/issue-flow-gate.yaml
+++ b/.github/workflows/issue-flow-gate.yaml
@@ -28,7 +28,7 @@ on:
       CODEX_REVIEW_GH_TOKEN:
         required: false
   pull_request:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, labeled, unlabeled, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read

--- a/templates/issue-flow-gate-caller.yaml
+++ b/templates/issue-flow-gate-caller.yaml
@@ -3,7 +3,7 @@ name: Issue Flow Gate
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, labeled, unlabeled, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
Refs #66

Summary:
- rerun the reusable issue flow gate when PR labels are added or removed
- keep the caller template in sync

Validation:
- scripts/validate-workflows.sh
- git diff --check

Umbrella rollout tracker: Trips issue 93