### PR TITLE
docs: mark Trips platform active

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **Platform active.** `https://viators.net`, `https://api.viators.net`, and inbound `trips@viators.net` are live. Verify current runtime state before deploy or incident conclusions.
+
 # AGENTS.md — Trips CI (`jai/trips-ci`)
 
 ## Repo Identity


### PR DESCRIPTION
## Summary
- mark the Trips platform as active in AGENTS.md
- remove stale production-paused guidance where present
- keep runtime verification as the source of truth before deploy or incident conclusions

Closes #69

## Validation
- docs-only change
- `git diff --check`
