### PR TITLE
docs: reference Trips E2E evidence standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@
 - Avoid compatibility indirection unless explicitly requested.
 - Ship quickly, but keep critical gating checks reliable.
 
+## End-to-End Evidence Standard
+
+- Follow the central `jai/trips` `AGENTS.md` end-to-end evidence standard.
+- Workflow changes must preserve fail-fast CI behavior for production-like E2E checks and must not turn cross-repo feature evidence into sliced-only coverage.
+- For email attachments, the expected CI evidence is a raw RFC822 email with an actual retained attachment flowing through worker ingest, API persistence/download endpoints, frontend UI visibility, and a successful attachment download.
+
 ## Structure
 
 ```


### PR DESCRIPTION
## Summary
- reference the central Trips E2E evidence standard from trips-ci AGENTS.md
- require shared CI changes to preserve production-like ingress-to-output checks for cross-repo features

## Related Issue
Closes #75 (Reference Trips E2E evidence standard)

## Validation
- [x] git diff --check