### PR TITLE
docs(agents): surface templates dir and refresh workflow list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 ## Repo Identity
 
 - Shared GitHub Actions workflows for Trips repositories.
-- Typical workflows include semantic PR checks, PR-issue linking, coverage, auto-merge, and code review orchestration.
+- Typical workflows include `pull-request-validation.yaml` (the canonical PR check covering semantic title, PR-issue linking, and required checks), `code-review*.yaml` (Codex review orchestration), `auto-merge.yaml`, `coverage-octocov.yml`, `issue-flow-gate.yaml`, `pr-image-check.yaml`, and `validate-workflows.yaml`.
 
 ## Project Mode (Solo MVP)
 
@@ -34,13 +34,16 @@
 trips-ci/
 ├── .github/workflows/
 ├── docs/
-└── scripts/
+├── scripts/
+└── templates/
 ```
+
+- `templates/` holds caller-workflow templates rendered by `scripts/generate-caller-workflows.sh` into each downstream repo's `.github/workflows/`.
 
 ## Commands
 
-- Validate workflow YAMLs (local checks as needed): `gh workflow list`
-- Trigger/review runs via `gh run list`, `gh run view`, `gh run rerun`
+- `scripts/generate-caller-workflows.sh [--check|--stdout] [target-dir...]` regenerates caller workflows in downstream repos. With no arguments it uses the hardcoded `DEFAULT_TARGETS` (umbrella subrepo paths under `/Users/jai/Developer/trips/`).
+- `scripts/validate-workflows.sh` validates the rendered output.
 
 ## Owner
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ trips-ci/
 └── templates/
 ```
 
-- `templates/` holds caller-workflow templates rendered by `scripts/generate-caller-workflows.sh` into each downstream repo's `.github/workflows/`.
+- `templates/` holds caller-workflow templates copied or rendered into each downstream repo's `.github/workflows/`. Today `scripts/generate-caller-workflows.sh` only renders `templates/code-review-caller.yaml` -> `code-review.yaml`; other templates here (e.g. `issue-flow-gate-caller.yaml`) are propagated manually or via other automation.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Add `templates/` to AGENTS.md Structure (caller-workflow templates rendered into downstream repos).
- Replace generic Commands with the two real scripts (`scripts/generate-caller-workflows.sh` and `scripts/validate-workflows.sh`).
- Refresh the workflows list to reflect the post-consolidation reality (`pull-request-validation.yaml` is now the canonical PR check).
- Add `CLAUDE.md` symlink to `AGENTS.md` so Claude Code picks up instructions automatically.

## Related Issue

Closes #77

## Validation

- [x] `git diff --cached --raw` confirms `CLAUDE.md` added as mode 120000 symlink.
- [x] `codex review --base main` pre-push gate: no blockers.
- [ ] Cloud `/review` (Codex reviewer) on the open PR.
- [ ] CI checks (`pull-request-validation`, `validate-workflows`) pass.