### PR TITLE
fix(ci): harden conversational Codex responses

### DIFF
--- a/.github/workflows/code-review-respond.yaml
+++ b/.github/workflows/code-review-respond.yaml
@@ -38,10 +38,6 @@ jobs:
   respond:
     runs-on: ubicloud-standard-2
     timeout-minutes: 30
-    env:
-      # Use the Trips review token so comments are attributed consistently.
-      GITHUB_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
-      GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
     if: |
       (
         github.event_name == 'issue_comment' &&
@@ -57,6 +53,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+          persist-credentials: false
 
       - name: Extract PR number
         id: extract-pr
@@ -204,23 +201,17 @@ jobs:
 
           The user has commented on a specific line of code in ${{ steps.extract-comment.outputs.file_path }} at line ${{ steps.extract-comment.outputs.line_number }}.
 
-          IMPORTANT: To reply to this inline comment, use the following API endpoint:
-          gh api -X POST /repos/${{ github.repository }}/pulls/${{ steps.extract-pr.outputs.pr_number }}/comments \\
-            -f body='Your reply message' \\
-            -F in_reply_to=${{ steps.extract-comment.outputs.comment_id }}
-
           Analyze their comment and respond appropriately:
           - If they're asking a question about the code, answer it directly
           - If they're pointing out an issue, acknowledge and discuss it
           - If they're requesting a change, evaluate and respond
           - Focus on the specific code context they're commenting on
           - Be concise and directly relevant to their comment
-          - Use the in_reply_to parameter to create a threaded reply
 
           CONVERSATIONAL-ONLY RULE (MANDATORY):
           - Never approve a PR and never request changes in this workflow.
           - Never run gh pr review --approve or gh pr review --request-changes.
-          - Only post conversational replies/comments relevant to the user's message."
+          - Do not post comments or call GitHub APIs. Write only the reply body; this workflow posts it deterministically."
           else
             FULL_PROMPT="${BASE_CONTEXT}
 
@@ -239,10 +230,7 @@ jobs:
           CONVERSATIONAL-ONLY RULE (MANDATORY):
           - Never approve a PR and never request changes in this workflow.
           - Never run gh pr review --approve or gh pr review --request-changes.
-          - Only post conversational replies/comments relevant to the user's message.
-
-          IMPORTANT: To respond to this PR comment, use:
-          gh pr comment --body 'Your response here'"
+          - Do not post comments or call GitHub APIs. Write only the reply body; this workflow posts it deterministically."
           fi
 
           echo "prompt<<EOF" >> $GITHUB_OUTPUT
@@ -304,13 +292,13 @@ jobs:
           codex login status
 
       - name: Run Codex response
+        id: run-codex
         if: steps.extract-pr.outputs.has_pr == 'true'
         shell: bash
         env:
           HOME: ${{ runner.temp }}/codex-home
           CODEX_MODEL: ${{ inputs.codex_model }}
           CODEX_REASONING_EFFORT: ${{ inputs.codex_reasoning_effort }}
-          GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
         run: |
           set -euo pipefail
           prompt_content="$(cat prompt.txt)"
@@ -350,4 +338,36 @@ jobs:
             fi
             exit "$status"
           fi
+          if [ ! -s codex-output.txt ]; then
+            echo "Codex produced an empty response." >&2
+            exit 1
+          fi
           cat codex-output.txt
+
+      - name: Post Codex response
+        if: steps.extract-pr.outputs.has_pr == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
+          COMMENT_TYPE: ${{ steps.extract-comment.outputs.comment_type }}
+          PR_NUMBER: ${{ steps.extract-pr.outputs.pr_number }}
+          COMMENT_ID: ${{ steps.extract-comment.outputs.comment_id }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -s codex-output.txt ]]; then
+            echo "Codex response file is missing or empty." >&2
+            exit 1
+          fi
+
+          if [[ "$COMMENT_TYPE" == "inline_comment" ]]; then
+            response_body="$(cat codex-output.txt)"
+            gh api -X POST "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
+              -f body="$response_body" \
+              -F in_reply_to="$COMMENT_ID" \
+              > /dev/null
+          else
+            gh pr comment "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file codex-output.txt
+          fi

--- a/.github/workflows/code-review-respond.yaml
+++ b/.github/workflows/code-review-respond.yaml
@@ -38,6 +38,11 @@ jobs:
   respond:
     runs-on: ubicloud-standard-2
     timeout-minutes: 30
+    outputs:
+      has_pr: ${{ steps.extract-pr.outputs.has_pr }}
+      pr_number: ${{ steps.extract-pr.outputs.pr_number }}
+      comment_type: ${{ steps.extract-comment.outputs.comment_type }}
+      comment_id: ${{ steps.extract-comment.outputs.comment_id }}
     if: |
       (
         github.event_name == 'issue_comment' &&
@@ -344,24 +349,45 @@ jobs:
           fi
           cat codex-output.txt
 
-      - name: Post Codex response
+      - name: Upload Codex response
         if: steps.extract-pr.outputs.has_pr == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-response-${{ github.run_id }}-${{ github.run_attempt }}
+          path: codex-output.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  post-response:
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 10
+    needs: respond
+    if: needs.respond.outputs.has_pr == 'true'
+    steps:
+      - name: Download Codex response
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-response-${{ github.run_id }}-${{ github.run_attempt }}
+          path: codex-response
+
+      - name: Post Codex response
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.CODEX_REVIEW_GH_TOKEN }}
-          COMMENT_TYPE: ${{ steps.extract-comment.outputs.comment_type }}
-          PR_NUMBER: ${{ steps.extract-pr.outputs.pr_number }}
-          COMMENT_ID: ${{ steps.extract-comment.outputs.comment_id }}
+          COMMENT_TYPE: ${{ needs.respond.outputs.comment_type }}
+          PR_NUMBER: ${{ needs.respond.outputs.pr_number }}
+          COMMENT_ID: ${{ needs.respond.outputs.comment_id }}
         run: |
           set -euo pipefail
 
-          if [[ ! -s codex-output.txt ]]; then
+          response_file="codex-response/codex-output.txt"
+          if [[ ! -s "$response_file" ]]; then
             echo "Codex response file is missing or empty." >&2
             exit 1
           fi
 
           if [[ "$COMMENT_TYPE" == "inline_comment" ]]; then
-            response_body="$(cat codex-output.txt)"
+            response_body="$(cat "$response_file")"
             gh api -X POST "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
               -f body="$response_body" \
               -F in_reply_to="$COMMENT_ID" \
@@ -369,5 +395,5 @@ jobs:
           else
             gh pr comment "$PR_NUMBER" \
               --repo "$GITHUB_REPOSITORY" \
-              --body-file codex-output.txt
+              --body-file "$response_file"
           fi

--- a/.github/workflows/issue-flow-gate.yaml
+++ b/.github/workflows/issue-flow-gate.yaml
@@ -46,7 +46,7 @@ jobs:
           ALLOWED_READY_LABELS: ${{ inputs.allowed_ready_labels || 'implementation-ready,ready' }}
           BLOCKED_LABELS: ${{ inputs.blocked_labels || 'needs-spec,needs-design,requirements-unclear,blocked,not-ready,do-not-start,human-intervention-needed' }}
           EXEMPT_PR_LABELS: ${{ inputs.exempt_pr_labels || 'flow-exempt' }}
-          SKIP_BOT_AUTHORS: ${{ inputs.skip_bot_authors || 'true' }}
+          SKIP_BOT_AUTHORS: ${{ format('{0}', inputs.skip_bot_authors) != 'false' }}
         with:
           github-token: ${{ secrets.CODEX_REVIEW_GH_TOKEN || github.token }}
           script: |

--- a/docs/review-workflow-validation-matrix.md
+++ b/docs/review-workflow-validation-matrix.md
@@ -359,7 +359,8 @@ BLOCKER=Merge conflict
   1. `respond` job runs with conversational prompt.
   2. `actions/checkout` does not persist the review token into local Git config.
   3. `Run Codex response` does not receive `GH_TOKEN` or `GITHUB_TOKEN`.
-  4. `Post Codex response` posts the generated body as an issue comment or inline reply.
+  4. `respond` uploads the generated body as a short-lived artifact.
+  5. `post-response` runs on a separate runner/job and posts the body as an issue comment or inline reply.
 - **Expected PR outcome**: No review state change. Only conversational reply posted.
 - **Evidence to capture**:
   - Run log shows `Post Codex response`, not a Codex-issued `gh pr review`.
@@ -380,7 +381,8 @@ RUN_ID=$(gh run list --repo "$REPO" --workflow "code-review.yaml" --limit 1 --js
 # 3. Static check: verify Codex cannot inherit the GitHub write token
 grep -n "persist-credentials: false" .github/workflows/code-review-respond.yaml
 grep -n "GH_TOKEN:.*CODEX_REVIEW_GH_TOKEN" .github/workflows/code-review-respond.yaml
-# PASS: checkout does not persist credentials; GH_TOKEN appears only in the deterministic post step
+grep -n "^  post-response:" .github/workflows/code-review-respond.yaml
+# PASS: checkout does not persist credentials; GH_TOKEN appears only in the separate post-response job
 
 # 4. Assert: no new review state changes from automation user
 REVIEWS_BEFORE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate | jq 'length')

--- a/docs/review-workflow-validation-matrix.md
+++ b/docs/review-workflow-validation-matrix.md
@@ -357,12 +357,12 @@ BLOCKER=Merge conflict
 - **Expected decision path**: No decision parsing occurs (respond workflow has no `parse-review-decision` step).
 - **Expected workflow actions**:
   1. `respond` job runs with conversational prompt.
-  2. Prompt contains `CONVERSATIONAL-ONLY RULE (MANDATORY)`.
-  3. Prompt forbids `gh pr review --approve` and `gh pr review --request-changes`.
-  4. Codex can only post conversational comments.
+  2. `actions/checkout` does not persist the review token into local Git config.
+  3. `Run Codex response` does not receive `GH_TOKEN` or `GITHUB_TOKEN`.
+  4. `Post Codex response` posts the generated body as an issue comment or inline reply.
 - **Expected PR outcome**: No review state change. Only conversational reply posted.
 - **Evidence to capture**:
-  - Prompt text contains `Never approve a PR and never request changes`.
+  - Run log shows `Post Codex response`, not a Codex-issued `gh pr review`.
   - No new `APPROVED` or `CHANGES_REQUESTED` reviews from automation user.
 
 #### Validation Playbook
@@ -377,10 +377,10 @@ gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex Can you explain the app
 # 2. Wait for respond workflow to complete
 RUN_ID=$(gh run list --repo "$REPO" --workflow "code-review.yaml" --limit 1 --json databaseId -q '.[0].databaseId')
 
-# 3. Static check: verify the respond prompt forbids formal review state changes
-grep -c "Never approve a PR and never request changes" \
-  .github/workflows/code-review-respond.yaml
-# PASS: >= 1
+# 3. Static check: verify Codex cannot inherit the GitHub write token
+grep -n "persist-credentials: false" .github/workflows/code-review-respond.yaml
+grep -n "GH_TOKEN:.*CODEX_REVIEW_GH_TOKEN" .github/workflows/code-review-respond.yaml
+# PASS: checkout does not persist credentials; GH_TOKEN appears only in the deterministic post step
 
 # 4. Assert: no new review state changes from automation user
 REVIEWS_BEFORE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate | jq 'length')


### PR DESCRIPTION
## Summary
- prevent conversational Codex responses from receiving GitHub write credentials directly
- post generated replies through a deterministic workflow step
- fix issue-flow gate handling when skip_bot_authors is explicitly false

## Related Issue
Closes #79

## Validation
- scripts/validate-workflows.sh
- git diff --check
