### PR TITLE
ci: accept optional PAT in shared auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -2,11 +2,25 @@
 # Enables auto-merge (squash) on PRs as soon as they're opened.
 # Merge won't happen until all branch protection / ruleset requirements are met.
 # Called by downstream repos via workflow_call.
+#
+# IMPORTANT: callers should pass JAI_CI_PERSONAL_ACCESS_TOKEN via
+# `secrets: inherit` so the eventual squash-merge push to main is
+# authored by the PAT owner instead of GITHUB_TOKEN. Pushes authored
+# by GITHUB_TOKEN do not trigger downstream `push`-triggered workflows
+# (release-please, deploy, etc.), which silently breaks the release
+# pipeline. The secret is optional so callers without a release.yaml
+# can still consume this workflow; when absent, the workflow falls
+# back to github.token (current behavior; downstream workflows will
+# NOT fire on the merge push).
 ---
 name: Auto-Merge
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      JAI_CI_PERSONAL_ACCESS_TOKEN:
+        description: PAT used to author the squash-merge so downstream push-triggered workflows fire. Optional; falls back to github.token if absent.
+        required: false
 
 permissions:
   contents: write
@@ -23,4 +37,4 @@ jobs:
             "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.JAI_CI_PERSONAL_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -3,15 +3,14 @@
 # Merge won't happen until all branch protection / ruleset requirements are met.
 # Called by downstream repos via workflow_call.
 #
-# IMPORTANT: callers should pass JAI_CI_PERSONAL_ACCESS_TOKEN via
-# `secrets: inherit` so the eventual squash-merge push to main is
-# authored by the PAT owner instead of GITHUB_TOKEN. Pushes authored
-# by GITHUB_TOKEN do not trigger downstream `push`-triggered workflows
-# (release-please, deploy, etc.), which silently breaks the release
-# pipeline. The secret is optional so callers without a release.yaml
-# can still consume this workflow; when absent, the workflow falls
-# back to github.token (current behavior; downstream workflows will
-# NOT fire on the merge push).
+# IMPORTANT: callers should explicitly pass JAI_CI_PERSONAL_ACCESS_TOKEN
+# so the eventual squash-merge push to main is authored by the PAT owner
+# instead of GITHUB_TOKEN. Pushes authored by GITHUB_TOKEN do not trigger
+# downstream `push`-triggered workflows (release-please, deploy, etc.),
+# which silently breaks the release pipeline. The secret is optional so
+# callers without a release.yaml can still consume this workflow; when
+# absent, the workflow falls back to github.token (current behavior;
+# downstream workflows will NOT fire on the merge push).
 ---
 name: Auto-Merge
 


### PR DESCRIPTION
## Summary

- Accept `JAI_CI_PERSONAL_ACCESS_TOKEN` as an optional `workflow_call` secret in the shared auto-merge workflow.
- Use it as `GH_TOKEN` for the `gh pr merge --auto --squash` invocation, falling back to `github.token` when not provided.
- Document why the PAT path matters: pushes attributed to `GITHUB_TOKEN` do not trigger downstream push-triggered workflows, which has silently broken release-please across the Trips platform.

## Related Issue

Fixes #80

## Validation

- [x] `git diff` reviewed: only `auto-merge.yaml` touched; one secret declaration plus `${{ secrets.JAI_CI_PERSONAL_ACCESS_TOKEN || github.token }}` fallback.
- [x] Local `codex review --base main` ran and returned no blockers.
- [x] YAML structure preserves all existing behavior; callers that do not pass the secret continue to use `github.token`.

## Notes

- Caller workflows in `trips-email-ingest-worker`, `trips-frontend`, `trips-api`, `trips`, and `trips-infra` are updated in separate PRs to pass `secrets: inherit`. Repos without the PAT secret (umbrella, infra) silently fall back to `github.token`.
- Cloud Codex review is the gate; if it hits limits today, local codex review already passed.