### PR TITLE
ci: pass cross-repo issue token to PR body validator

### DIFF
--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -2,7 +2,10 @@
 name: Pull Request Validation
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      CODEX_REVIEW_GH_TOKEN:
+        required: false
   pull_request:
     types:
       - opened
@@ -42,6 +45,7 @@ jobs:
       - name: Validate PR body
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.CODEX_REVIEW_GH_TOKEN || github.token }}
           script: |
             const pr = context.payload.pull_request;
             if (!pr) {


### PR DESCRIPTION
## Summary
- Fix the `Validate PR body` step in the reusable `pull-request-validation.yaml` so it can verify cross-repo auto-closing issue references.
- It used the default repo-scoped `github.token` for `github.rest.issues.get`, so a component-repo PR closing an umbrella `jai/trips#N` issue failed with "Not Found".
- Mirror the `issue-flow-gate.yaml` pattern: accept optional `CODEX_REVIEW_GH_TOKEN` and use it (fallback `github.token`).

## Related Issue
Closes #82

## Validation
- actionlint / shellcheck via the repo's Validate Workflows job.
- Downstream: the trips-api caller will pass `CODEX_REVIEW_GH_TOKEN` (paired change); end-to-end verified against `jai/trips-api#297` (`Closes jai/trips#119`) once both land.
