### PR TITLE
ci: move automation to Mac mini SSD runner

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   enable-auto-merge:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Enable auto-merge (squash)
         run: |

--- a/.github/workflows/code-review-full.yaml
+++ b/.github/workflows/code-review-full.yaml
@@ -77,7 +77,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 30
     env:
       # Use the Trips review token so review comments and formal reviews are attributed consistently.
@@ -692,7 +692,7 @@ jobs:
     name: Review Orchestration
     needs: review
     if: ${{ needs.review.outputs.decision_found == 'true' }}
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/code-review-respond.yaml
+++ b/.github/workflows/code-review-respond.yaml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   respond:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 30
     outputs:
       has_pr: ${{ steps.extract-pr.outputs.has_pr }}
@@ -359,7 +359,7 @@ jobs:
           retention-days: 1
 
   post-response:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 10
     needs: respond
     if: needs.respond.outputs.has_pr == 'true'

--- a/.github/workflows/code-review-welcome.yaml
+++ b/.github/workflows/code-review-welcome.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   welcome:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage-octocov.yml
+++ b/.github/workflows/coverage-octocov.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   octocov:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/issue-flow-gate.yaml
+++ b/.github/workflows/issue-flow-gate.yaml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   issue-flow:
     name: Validate linked issue flow
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Validate linked issues are implementation-ready
         uses: actions/github-script@v7

--- a/.github/workflows/pr-image-check.yaml
+++ b/.github/workflows/pr-image-check.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-images:
     name: Validate PR Images
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Check PR markdown image URLs
         env:

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   validate-pr:
     name: Validate PR
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Validate semantic title
         uses: amannn/action-semantic-pull-request@v6

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Replace UbiCloud runner labels with the repository-scoped `jai-ci` runner.
- Run GitHub Actions jobs in the Mac mini Linux VM stored on the external SSD.

## Related Issue
Closes #92

## Validation
- `actionlint` passed for every changed workflow with the established custom self-hosted label allowed.
- `git diff --check` passed.