### PR TITLE
ci: run shared Trips workflows on the Mac mini SSD

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   enable-auto-merge:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Enable auto-merge (squash)
         run: |

--- a/.github/workflows/code-review-full.yaml
+++ b/.github/workflows/code-review-full.yaml
@@ -77,7 +77,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 30
     env:
       # Use the Trips review token so review comments and formal reviews are attributed consistently.
@@ -692,7 +692,7 @@ jobs:
     name: Review Orchestration
     needs: review
     if: ${{ needs.review.outputs.decision_found == 'true' }}
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/code-review-respond.yaml
+++ b/.github/workflows/code-review-respond.yaml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   respond:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 30
     outputs:
       has_pr: ${{ steps.extract-pr.outputs.has_pr }}
@@ -359,7 +359,7 @@ jobs:
           retention-days: 1
 
   post-response:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     timeout-minutes: 10
     needs: respond
     if: needs.respond.outputs.has_pr == 'true'

--- a/.github/workflows/code-review-welcome.yaml
+++ b/.github/workflows/code-review-welcome.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   welcome:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage-octocov.yml
+++ b/.github/workflows/coverage-octocov.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   octocov:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/issue-flow-gate.yaml
+++ b/.github/workflows/issue-flow-gate.yaml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   issue-flow:
     name: Validate linked issue flow
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Validate linked issues are implementation-ready
         uses: actions/github-script@v7

--- a/.github/workflows/pr-image-check.yaml
+++ b/.github/workflows/pr-image-check.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-images:
     name: Validate PR Images
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Check PR markdown image URLs
         env:

--- a/.github/workflows/pull-request-validation.yaml
+++ b/.github/workflows/pull-request-validation.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   validate-pr:
     name: Validate PR
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - name: Validate semantic title
         uses: amannn/action-semantic-pull-request@v6

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubicloud-standard-2
+    runs-on: [self-hosted, linux, arm64, jai-ci]
     steps:
       - uses: actions/checkout@v4
 

--- a/launchd/com.jai.trips-tart-runner.plist
+++ b/launchd/com.jai.trips-tart-runner.plist
@@ -4,12 +4,11 @@
 <dict>
   <key>Label</key><string>com.jai.trips-tart-runner</string>
   <key>ProgramArguments</key>
-  <array><string>/Users/jai/.local/bin/trips-tart-runner-controller</string></array>
+  <array><string>/Users/jai/.local/bin/start-trips-tart-runner.command</string></array>
   <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
+  <key>StartInterval</key><integer>60</integer>
   <key>ProcessType</key><string>Background</string>
-  <key>ThrottleInterval</key><integer>30</integer>
-  <key>StandardOutPath</key><string>/Users/jai/Library/Logs/trips-tart-runner/controller.log</string>
-  <key>StandardErrorPath</key><string>/Users/jai/Library/Logs/trips-tart-runner/controller.err</string>
+  <key>StandardOutPath</key><string>/Users/jai/Library/Logs/trips-tart-runner/launcher.log</string>
+  <key>StandardErrorPath</key><string>/Users/jai/Library/Logs/trips-tart-runner/launcher.err</string>
 </dict>
 </plist>

--- a/scripts/start-trips-tart-runner.command
+++ b/scripts/start-trips-tart-runner.command
@@ -1,0 +1,31 @@
+#!/bin/zsh
+set -u
+
+PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+readonly required_volume="/Volumes/mac-mini-external"
+readonly tart_home="${required_volume}/tart"
+readonly work_disk_directory="${required_volume}/trips-tart-runner/work-disks"
+readonly controller="/Users/jai/.local/bin/trips-tart-runner-controller"
+
+if ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
+  exit 0
+fi
+
+if /usr/bin/pgrep -f '/Users/jai/.local/bin/trips-tart-runner-controller' >/dev/null; then
+  exit 0
+fi
+
+# launchd processes are denied direct removable-volume access by macOS TCC.
+# Re-open this command in Terminal, whose logged-in user context is authorized.
+if [[ "${TERM_PROGRAM:-}" != "Apple_Terminal" ]]; then
+  /usr/bin/open -gj -a Terminal "$0"
+  exit 0
+fi
+
+export TART_HOME="$tart_home"
+export TRIPS_TART_REQUIRED_VOLUME="$required_volume"
+export TRIPS_TART_RUNNER_HOST_LABEL="jais-mac-mini"
+export TRIPS_TART_RUNNER_NAME_PREFIX="jais-mac-mini-tart"
+export TRIPS_TART_WORK_DISK_DIRECTORY="$work_disk_directory"
+exec "$controller"

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -20,7 +20,7 @@ mkdir -p "$tmp_dir/.github/workflows"
 
 actionlint_args=(
   -shellcheck=
-  -ignore 'label "ubicloud-standard-2" is unknown'
+  -ignore 'label "jai-ci" is unknown'
 )
 
 actionlint "${actionlint_args[@]}" "$repo_root"/.github/workflows/*.yaml


### PR DESCRIPTION
## Summary
- make Tart startup TCC-aware through the logged-in Terminal context
- keep ephemeral iOS Tart execution on the external SSD
- route every shared Linux workflow to the SSD-backed Lima runner

## Related Issue
Closes #94

## Validation
- [x] zsh syntax check passes for the Tart launcher
- [x] launchd plist validation passes
- [x] launchd provisioned an online ephemeral Tart runner after Full Disk Access was enabled
- [x] actionlint passes for all changed workflows
- [x] iOS build-only proof: https://github.com/jai/trips-frontend/actions/runs/32348832153