### PR TITLE
fix: bound unclaimed Tart runners and API polling

### DIFF
--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -7,12 +7,14 @@ on:
       - ".github/workflows/**"
       - "scripts/**"
       - "templates/**"
+      - "tests/**"
   push:
     branches: [main]
     paths:
       - ".github/workflows/**"
       - "scripts/**"
       - "templates/**"
+      - "tests/**"
 
 permissions:
   contents: read
@@ -33,7 +35,7 @@ jobs:
           set -euo pipefail
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
           sudo apt-get update
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck zsh
 
       - name: Validate workflow library
         shell: bash

--- a/scripts/start-trips-linux-tart-runner.command
+++ b/scripts/start-trips-linux-tart-runner.command
@@ -11,7 +11,7 @@ if ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
   exit 0
 fi
 
-if /usr/bin/pgrep -f '/Users/jai/.local/bin/trips-linux-tart-runner-controller' >/dev/null; then
+if /usr/bin/pgrep -f '^/bin/zsh /Users/jai/.local/bin/trips-linux-tart-runner-controller$' >/dev/null; then
   exit 0
 fi
 

--- a/scripts/start-trips-tart-runner.command
+++ b/scripts/start-trips-tart-runner.command
@@ -12,7 +12,7 @@ if ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
   exit 0
 fi
 
-if /usr/bin/pgrep -f '/Users/jai/.local/bin/trips-tart-runner-controller' >/dev/null; then
+if /usr/bin/pgrep -f '^/bin/zsh /Users/jai/.local/bin/trips-tart-runner-controller$' >/dev/null; then
   exit 0
 fi
 

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -56,8 +56,9 @@ acquire_priority_lock() { acquire_lock "$native_priority_lock"; }
 release_priority_lock() { release_lock "$native_priority_lock"; }
 
 shared_lane_has_ephemeral_vm() {
-  /opt/homebrew/bin/tart list --source local --quiet |
-    /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
+  local vm_list
+  vm_list=$(/opt/homebrew/bin/tart list --source local --quiet) || return 0
+  printf '%s\n' "$vm_list" | /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
 }
 
 acquire_clean_lane_lock() {
@@ -418,6 +419,7 @@ run_one_ephemeral_runner() {
       wait "$vm_pid" >/dev/null 2>&1 || true
     fi
   }
+  [[ "$cleanup_allowed" == true ]] || runner_status=3
   return "$runner_status"
 }
 
@@ -496,6 +498,10 @@ main() {
         2)
           log "yielding the shared Tart lane to the waiting native controller"
           /bin/sleep "$lane_poll_seconds"
+          ;;
+        3)
+          log "preserved an ambiguous runner; exiting for startup reconciliation"
+          return 1
           ;;
         *)
           log "ephemeral runner cycle failed for ${repository}; retrying in 15 seconds"

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -113,14 +113,16 @@ runner_id() {
     --jq ".runners[] | select(.name == \"${runner_name}\") | .id"
 }
 
-runner_is_busy() {
-  local repository="$1" runner_name="$2"
-  /opt/homebrew/bin/gh api \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2022-11-28' \
-    "repos/${repository}/actions/runners?per_page=100" \
-    --jq ".runners[] | select(.name == \"${runner_name}\") | .busy" |
-    /usr/bin/grep -qx 'true'
+runner_worker_started() {
+  local vm_ip="$1"
+  /usr/bin/ssh \
+    -o BatchMode=yes \
+    -o ConnectTimeout=3 \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "$ssh_key" \
+    "admin@${vm_ip}" \
+    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null" 2>/dev/null
 }
 
 delete_runner_registration() {
@@ -212,7 +214,11 @@ run_one_ephemeral_runner() {
         runner_claimed=true
         break
       fi
-      if runner_is_busy "$repository" "$runner_name"; then
+      # GitHub's runner busy flag can become true before the broker actually
+      # starts a job, and can remain stale when dispatch fails. Only the worker
+      # process proves this VM accepted executable work; otherwise keep the
+      # bounded idle timer running and recycle the runner after five minutes.
+      if runner_worker_started "$vm_ip"; then
         runner_claimed=true
         wait "$runner_pid"
         runner_status=$?

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -33,47 +33,32 @@ log() {
   print -r -- "$(timestamp) $*"
 }
 
-acquire_controller_lock() {
-  local owner_pid=""
-  if /bin/mkdir "$lock_directory" 2>/dev/null; then
-    printf '%s\n' $$ >"${lock_directory}/owner.pid"
+acquire_lock() {
+  local lock_path="$1" owner_pid="" candidate
+  candidate="${lock_path}.$$"
+  printf '%s\n' $$ >"$candidate"
+  if /bin/ln "$candidate" "$lock_path" 2>/dev/null; then
+    /bin/rm -f "$candidate"
     return 0
   fi
-  [[ -r "${lock_directory}/owner.pid" ]] || return 1
-  read -r owner_pid <"${lock_directory}/owner.pid"
-  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
-    return 1
-  fi
-  /bin/rm -f "${lock_directory}/owner.pid"
-  /bin/rmdir "$lock_directory" 2>/dev/null || return 1
-  /bin/mkdir "$lock_directory" 2>/dev/null || return 1
-  printf '%s\n' $$ >"${lock_directory}/owner.pid"
-}
-
-release_controller_lock() {
-  /bin/rm -f "${lock_directory}/owner.pid"
-  /bin/rmdir "$lock_directory" >/dev/null 2>&1 || true
-}
-
-acquire_lane_lock() {
-  local owner_pid=""
-  if /bin/mkdir "$lane_lock_directory" 2>/dev/null; then
-    printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
-    return 0
-  fi
-  [[ -r "${lane_lock_directory}/owner.pid" ]] || return 1
-  read -r owner_pid <"${lane_lock_directory}/owner.pid"
+  /bin/rm -f "$candidate"
+  [[ -r "$lock_path" ]] || return 1
+  read -r owner_pid <"$lock_path"
   if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then return 1; fi
-  /bin/rm -f "${lane_lock_directory}/owner.pid"
-  /bin/rmdir "$lane_lock_directory" 2>/dev/null || return 1
-  /bin/mkdir "$lane_lock_directory" 2>/dev/null || return 1
-  printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
+  /bin/rm -f "$lock_path"
+  acquire_lock "$lock_path"
 }
 
-release_lane_lock() {
-  /bin/rm -f "${lane_lock_directory}/owner.pid"
-  /bin/rmdir "$lane_lock_directory" >/dev/null 2>&1 || true
+release_lock() {
+  local lock_path="$1" owner_pid=""
+  [[ -r "$lock_path" ]] && read -r owner_pid <"$lock_path"
+  [[ "$owner_pid" != $$ ]] || /bin/rm -f "$lock_path"
 }
+
+acquire_controller_lock() { acquire_lock "$lock_directory"; }
+release_controller_lock() { release_lock "$lock_directory"; }
+acquire_lane_lock() { acquire_lock "$lane_lock_directory"; }
+release_lane_lock() { release_lock "$lane_lock_directory"; }
 
 base64url() {
   /usr/bin/openssl base64 -A | /usr/bin/tr '+/' '-_' | /usr/bin/tr -d '='
@@ -161,7 +146,7 @@ repository_has_queued_job() {
 user_api_has_headroom() {
   local remaining
   remaining=$(/opt/homebrew/bin/gh api rate_limit --jq '.resources.core.remaining') || return 1
-  [[ "$remaining" == <1000-> ]]
+  [[ "$remaining" == <1500-> ]]
 }
 
 next_repository() {
@@ -176,10 +161,11 @@ next_repository() {
 }
 
 delete_vm() {
-  local vm_name="$1"
+  local vm_name="$1" vm_list
   /opt/homebrew/bin/tart stop "$vm_name" >/dev/null 2>&1 || true
   /opt/homebrew/bin/tart delete "$vm_name" >/dev/null 2>&1 || true
-  ! /opt/homebrew/bin/tart list --source local --quiet | /usr/bin/grep -qx "$vm_name" || {
+  vm_list=$(/opt/homebrew/bin/tart list --source local --quiet) || return 1
+  ! printf '%s\n' "$vm_list" | /usr/bin/grep -qx "$vm_name" || {
     log "failed to delete ${vm_name}"
     return 1
   }
@@ -449,14 +435,14 @@ main() {
         fi
       fi
       log "removing safely stopped stale ephemeral VM ${stale_vm}"
-      delete_vm "$stale_vm"
+      delete_vm "$stale_vm" || return 1
     fi
   done < <(/opt/homebrew/bin/tart list --source local --quiet)
   [[ "$preserved_stale" == false ]] || return 1
 
   while true; do
     if ! user_api_has_headroom; then
-      log "GitHub user API has less than 1,000 core requests remaining; pausing discovery for 180 seconds"
+      log "GitHub user API has less than 1,500 core requests remaining; pausing discovery for 180 seconds"
       /bin/sleep 180
       continue
     fi
@@ -469,7 +455,7 @@ main() {
       fi
     else
       # Server-side status filters avoid losing active runs behind completed runs.
-      # Discovery stops with 1,000 requests in reserve and idles between passes.
+      # A pass costs at most 336 requests, preserving at least 1,164 in reserve.
       /bin/sleep 180
     fi
   done

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -18,6 +18,7 @@ readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
 readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
 readonly native_priority_file="${TRIPS_TART_NATIVE_PRIORITY_FILE:-/Users/jai/Library/Logs/trips-tart-runner-native-priority}"
+readonly native_priority_lock="${native_priority_file}.lock"
 readonly lane_poll_seconds="${TRIPS_TART_LANE_POLL_SECONDS:-15}"
 
 typeset -g github_installation_token=""
@@ -25,7 +26,9 @@ typeset -g github_installation_token_expires_at=0
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
-mkdir -p "$log_directory"
+if [[ "${TRIPS_RUNNER_CONTROLLER_TEST_MODE:-false}" != true ]]; then
+  mkdir -p "$log_directory"
+fi
 
 timestamp() {
   /bin/date -u '+%Y-%m-%dT%H:%M:%SZ'
@@ -49,22 +52,43 @@ acquire_controller_lock() { acquire_lock "$lock_directory"; }
 release_controller_lock() { release_lock "$lock_directory"; }
 acquire_lane_lock() { acquire_lock "$lane_lock_directory"; }
 release_lane_lock() { release_lock "$lane_lock_directory"; }
+acquire_priority_lock() { acquire_lock "$native_priority_lock"; }
+release_priority_lock() { release_lock "$native_priority_lock"; }
+
+shared_lane_has_ephemeral_vm() {
+  /opt/homebrew/bin/tart list --source local --quiet |
+    /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
+}
+
+acquire_clean_lane_lock() {
+  acquire_lane_lock || return 1
+  if shared_lane_has_ephemeral_vm; then
+    release_lane_lock
+    return 1
+  fi
+}
 
 native_lane_priority_requested() {
-  local owner_pid=""
-  [[ -r "$native_priority_file" ]] || return 1
+  local owner_pid="" requested=false
+  acquire_priority_lock || return 0
+  if [[ ! -r "$native_priority_file" ]]; then
+    release_priority_lock
+    return 1
+  fi
   read -r owner_pid <"$native_priority_file"
   if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
-    return 0
+    requested=true
+  else
+    /bin/rm -f "$native_priority_file"
   fi
-  /bin/rm -f "$native_priority_file"
-  return 1
+  release_priority_lock
+  [[ "$requested" == true ]]
 }
 
 acquire_linux_lane() {
   while true; do
     native_lane_priority_requested && return 2
-    if acquire_lane_lock; then
+    if acquire_clean_lane_lock; then
       if native_lane_priority_requested; then
         release_lane_lock
         return 2
@@ -121,10 +145,9 @@ github_api() {
 }
 
 registration_token() {
-  local repository="$1"
-  ensure_installation_token || return 1
+  local repository="$1" installation_token="$2"
   /usr/bin/curl -fsS -X POST \
-    -H "Authorization: Bearer $github_installation_token" \
+    -H "Authorization: Bearer $installation_token" \
     -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "https://api.github.com/repos/${repository}/actions/runners/registration-token" |
@@ -317,7 +340,8 @@ run_one_ephemeral_runner() {
     [[ "$ssh_ready" == true ]] || return 1
     log "${vm_name} booted"
 
-    token=$(registration_token "$repository") || return 1
+    ensure_installation_token || return 1
+    token=$(registration_token "$repository" "$github_installation_token") || return 1
     log "registering ${runner_name} for ${repository}"
     printf '%s\n' "$token" | /usr/bin/ssh \
       -o BatchMode=yes \
@@ -390,7 +414,9 @@ run_one_ephemeral_runner() {
   } always {
     trap - INT TERM
     cleanup_vm || runner_status=1
-    [[ -z "$vm_pid" ]] || wait "$vm_pid" >/dev/null 2>&1 || true
+    if [[ "$cleanup_allowed" == true && -n "$vm_pid" ]]; then
+      wait "$vm_pid" >/dev/null 2>&1 || true
+    fi
   }
   return "$runner_status"
 }

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -64,24 +64,28 @@ registration_token() {
 }
 
 repository_has_queued_job() {
-  local repository="$1" run_id
-  while IFS= read -r run_id; do
-    [[ -n "$run_id" ]] || continue
-    if /opt/homebrew/bin/gh api \
-      -H 'Accept: application/vnd.github+json' \
-      -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
-      --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length' |
-      /usr/bin/grep -qxv '0'; then
-      return 0
-    fi
-  done < <(
+  local repository="$1" run_id run_ids queued_job_count
+  run_ids=$(
     /opt/homebrew/bin/gh api \
       -H 'Accept: application/vnd.github+json' \
       -H 'X-GitHub-Api-Version: 2022-11-28' \
       "repos/${repository}/actions/runs?per_page=30" \
       --jq '.workflow_runs[] | select(.status == "queued" or .status == "in_progress") | .id'
-  )
+  ) || return 1
+
+  while IFS= read -r run_id; do
+    [[ -n "$run_id" ]] || continue
+    queued_job_count=$(
+      /opt/homebrew/bin/gh api \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
+      --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length'
+    ) || continue
+    if [[ "$queued_job_count" == <1-> ]]; then
+      return 0
+    fi
+  done <<<"$run_ids"
   return 1
 }
 
@@ -277,7 +281,7 @@ main() {
   while true; do
     if repository=$(next_repository); then
       if run_one_ephemeral_runner "$repository"; then
-        log "ephemeral runner completed a job for ${repository}"
+        log "ephemeral runner cycle completed for ${repository}"
       else
         log "ephemeral runner cycle failed for ${repository}; retrying in 15 seconds"
         /bin/sleep 15

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -120,6 +120,8 @@ runner_worker_started() {
   /usr/bin/ssh \
     -o BatchMode=yes \
     -o ConnectTimeout=3 \
+    -o ServerAliveInterval=2 \
+    -o ServerAliveCountMax=2 \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
     -i "$ssh_key" \
@@ -228,6 +230,13 @@ run_one_ephemeral_runner() {
       fi
       /bin/sleep 2
     done
+    # Recheck after the final sleep so a job accepted at the idle deadline is
+    # not killed without observing its worker.
+    if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
+      runner_claimed=true
+      wait "$runner_pid"
+      runner_status=$?
+    fi
     if [[ "$runner_claimed" == false ]]; then
       log "${runner_name} remained idle; removing it"
       /bin/kill "$runner_pid" 2>/dev/null || true

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -16,6 +16,7 @@ readonly ssh_key="/Users/jai/.config/trips-tart-runner/runner-controller-ed25519
 readonly log_directory="/Users/jai/Library/Logs/trips-linux-tart-runner"
 readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
+readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
 
 typeset -g github_installation_token=""
 typeset -g github_installation_token_expires_at=0
@@ -38,7 +39,8 @@ acquire_controller_lock() {
     printf '%s\n' $$ >"${lock_directory}/owner.pid"
     return 0
   fi
-  [[ -r "${lock_directory}/owner.pid" ]] && read -r owner_pid <"${lock_directory}/owner.pid"
+  [[ -r "${lock_directory}/owner.pid" ]] || return 1
+  read -r owner_pid <"${lock_directory}/owner.pid"
   if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
     return 1
   fi
@@ -51,6 +53,26 @@ acquire_controller_lock() {
 release_controller_lock() {
   /bin/rm -f "${lock_directory}/owner.pid"
   /bin/rmdir "$lock_directory" >/dev/null 2>&1 || true
+}
+
+acquire_lane_lock() {
+  local owner_pid=""
+  if /bin/mkdir "$lane_lock_directory" 2>/dev/null; then
+    printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
+    return 0
+  fi
+  [[ -r "${lane_lock_directory}/owner.pid" ]] || return 1
+  read -r owner_pid <"${lane_lock_directory}/owner.pid"
+  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then return 1; fi
+  /bin/rm -f "${lane_lock_directory}/owner.pid"
+  /bin/rmdir "$lane_lock_directory" 2>/dev/null || return 1
+  /bin/mkdir "$lane_lock_directory" 2>/dev/null || return 1
+  printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
+}
+
+release_lane_lock() {
+  /bin/rm -f "${lane_lock_directory}/owner.pid"
+  /bin/rmdir "$lane_lock_directory" >/dev/null 2>&1 || true
 }
 
 base64url() {
@@ -157,12 +179,22 @@ delete_vm() {
   local vm_name="$1"
   /opt/homebrew/bin/tart stop "$vm_name" >/dev/null 2>&1 || true
   /opt/homebrew/bin/tart delete "$vm_name" >/dev/null 2>&1 || true
+  ! /opt/homebrew/bin/tart list --source local --quiet | /usr/bin/grep -qx "$vm_name" || {
+    log "failed to delete ${vm_name}"
+    return 1
+  }
 }
 
 runner_id() {
   local repository="$1" runner_name="$2"
   github_api GET "repos/${repository}/actions/runners?per_page=100" |
     RUNNER_NAME="$runner_name" /usr/bin/python3 -c 'import json,os,sys; print(next((runner["id"] for runner in json.load(sys.stdin)["runners"] if runner["name"] == os.environ["RUNNER_NAME"]), ""))'
+}
+
+runner_registration_state() {
+  local repository="$1" runner_name="$2"
+  github_api GET "repos/${repository}/actions/runners?per_page=100" |
+    RUNNER_NAME="$runner_name" /usr/bin/python3 -c 'import json,os,sys; runner=next((r for r in json.load(sys.stdin)["runners"] if r["name"] == os.environ["RUNNER_NAME"]), None); print("missing" if runner is None else ("busy" if runner["busy"] else "idle"))' || print unreachable
 }
 
 runner_process_state() {
@@ -223,7 +255,7 @@ delete_runner_registration() {
 }
 
 run_one_ephemeral_runner() {
-  local repository="$1" suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed ssh_ready ios_runner_count linux_runner_count state missing_count cleanup_allowed
+  local repository="$1" suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed ssh_ready state missing_count cleanup_allowed registration_state lane_lock_owned
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-linux-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
@@ -231,23 +263,20 @@ run_one_ephemeral_runner() {
   vm_pid=""
   runner_status=1
   cleanup_allowed=true
+  lane_lock_owned=false
 
-  while true; do
-    ios_runner_count=$(
-      /opt/homebrew/bin/tart list --source local --quiet |
-        /usr/bin/grep -c '^trips-runner-job-' || true
-    )
-    linux_runner_count=$(
-      /opt/homebrew/bin/tart list --source local --quiet |
-        /usr/bin/grep -c '^trips-linux-runner-job-' || true
-    )
-    (( ios_runner_count == 0 && linux_runner_count == 0 )) && break
+  while ! acquire_lane_lock; do
     log "waiting because another Tart job VM is active"
     /bin/sleep 15
   done
+  lane_lock_owned=true
 
   log "cloning ${base_vm} to ${vm_name} for ${repository}"
-  /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || return 1
+  /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || {
+    release_lane_lock
+    lane_lock_owned=false
+    return 1
+  }
 
   cleanup_vm() {
     if [[ "$cleanup_allowed" != true ]]; then
@@ -255,7 +284,9 @@ run_one_ephemeral_runner() {
       return 0
     fi
     log "deleting ${vm_name}"
-    delete_vm "$vm_name"
+    delete_vm "$vm_name" || return 1
+    [[ "$lane_lock_owned" != true ]] || release_lane_lock
+    lane_lock_owned=false
   }
   trap 'cleanup_vm; exit 0' INT TERM
 
@@ -295,7 +326,10 @@ run_one_ephemeral_runner() {
       -o UserKnownHostsFile=/dev/null \
       -i "$ssh_key" \
       "admin@${vm_ip}" \
-      "IFS= read -r registration_token; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work _work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || return 1
+      "IFS= read -r registration_token; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work _work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || {
+        cleanup_allowed=false
+        return 1
+      }
     runner_claimed=false
     for _ in {1..150}; do
       state=$(runner_process_state "$vm_ip")
@@ -320,7 +354,7 @@ run_one_ephemeral_runner() {
           break
         elif [[ "$state" == absent ]]; then
           (( missing_count += 1 ))
-          (( missing_count >= 3 )) && break
+          (( missing_count >= 6 )) && break
         elif [[ "$state" == listener ]]; then
           stop_idle_listener "$vm_ip" >/dev/null
           missing_count=0
@@ -331,10 +365,20 @@ run_one_ephemeral_runner() {
       done
       if [[ "$runner_claimed" == true ]]; then
         wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
-      elif (( missing_count >= 3 )); then
-        log "${runner_name} drained without accepting a job; removing it"
-        delete_runner_registration "$repository" "$runner_name" || true
-        runner_status=0
+      elif (( missing_count >= 6 )); then
+        registration_state=$(runner_registration_state "$repository" "$runner_name")
+        if [[ "$registration_state" == busy ]]; then
+          runner_claimed=true
+          wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+        elif [[ "$registration_state" == idle || "$registration_state" == missing ]]; then
+          log "${runner_name} drained without accepting a job; removing it"
+          delete_runner_registration "$repository" "$runner_name" || true
+          runner_status=0
+        else
+          log "could not verify ${runner_name} registration state"
+          cleanup_allowed=false
+          runner_status=1
+        fi
       else
         log "could not prove ${runner_name} idle after draining"
         cleanup_allowed=false
@@ -343,7 +387,7 @@ run_one_ephemeral_runner() {
     fi
   } always {
     trap - INT TERM
-    cleanup_vm
+    cleanup_vm || runner_status=1
     [[ -z "$vm_pid" ]] || wait "$vm_pid" >/dev/null 2>&1 || true
   }
   return "$runner_status"
@@ -392,6 +436,14 @@ main() {
         stale_state=$(runner_process_state "$stale_ip")
         if [[ "$stale_state" != absent ]]; then
           log "preserving ${stale_vm}; live state is ${stale_state}"
+          preserved_stale=true
+          continue
+        fi
+      else
+        stale_state=$(/opt/homebrew/bin/tart list --source local --format json |
+          VM_NAME="$stale_vm" /usr/bin/python3 -c 'import json,os,sys; print(next((vm["State"] for vm in json.load(sys.stdin) if vm["Name"] == os.environ["VM_NAME"]), "unknown"))')
+        if [[ "$stale_state" != stopped ]]; then
+          log "preserving ${stale_vm}; state is ${stale_state} and no IP was available"
           preserved_stale=true
           continue
         fi

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -64,26 +64,24 @@ registration_token() {
 }
 
 repository_has_queued_job() {
-  local repository="$1" run_status run_id
-  for run_status in queued in_progress; do
-    while IFS= read -r run_id; do
-      [[ -n "$run_id" ]] || continue
-      if /opt/homebrew/bin/gh api \
-        -H 'Accept: application/vnd.github+json' \
-        -H 'X-GitHub-Api-Version: 2022-11-28' \
-        "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
-        --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length' |
-        /usr/bin/grep -qxv '0'; then
-        return 0
-      fi
-    done < <(
-      /opt/homebrew/bin/gh api \
-        -H 'Accept: application/vnd.github+json' \
-        -H 'X-GitHub-Api-Version: 2022-11-28' \
-        "repos/${repository}/actions/runs?status=${run_status}&per_page=20" \
-        --jq '.workflow_runs[].id'
-    )
-  done
+  local repository="$1" run_id
+  while IFS= read -r run_id; do
+    [[ -n "$run_id" ]] || continue
+    if /opt/homebrew/bin/gh api \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
+      --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length' |
+      /usr/bin/grep -qxv '0'; then
+      return 0
+    fi
+  done < <(
+    /opt/homebrew/bin/gh api \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "repos/${repository}/actions/runs?per_page=30" \
+      --jq '.workflow_runs[] | select(.status == "queued" or .status == "in_progress") | .id'
+  )
   return 1
 }
 
@@ -264,7 +262,7 @@ main() {
     log "failed to set ${base_vm} memory to ${base_memory_mb} MB"
     return 1
   fi
-  if ! /opt/homebrew/bin/gh auth status >/dev/null 2>&1; then
+  if ! /opt/homebrew/bin/gh auth token >/dev/null 2>&1; then
     log "GitHub CLI authentication is unavailable"
     return 1
   fi
@@ -285,7 +283,9 @@ main() {
         /bin/sleep 15
       fi
     else
-      /bin/sleep 5
+      # Eight repositories are inspected per pass. A 30-second cadence keeps
+      # idle discovery prompt without exhausting the user API allowance.
+      /bin/sleep 30
     fi
   done
 }

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -17,6 +17,7 @@ readonly log_directory="/Users/jai/Library/Logs/trips-linux-tart-runner"
 readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
 readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
+readonly native_priority_file="${TRIPS_TART_NATIVE_PRIORITY_FILE:-/Users/jai/Library/Logs/trips-tart-runner-native-priority}"
 
 typeset -g github_installation_token=""
 typeset -g github_installation_token_expires_at=0
@@ -59,6 +60,17 @@ acquire_controller_lock() { acquire_lock "$lock_directory"; }
 release_controller_lock() { release_lock "$lock_directory"; }
 acquire_lane_lock() { acquire_lock "$lane_lock_directory"; }
 release_lane_lock() { release_lock "$lane_lock_directory"; }
+
+native_lane_priority_requested() {
+  local owner_pid=""
+  [[ -r "$native_priority_file" ]] || return 1
+  read -r owner_pid <"$native_priority_file"
+  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
+    return 0
+  fi
+  /bin/rm -f "$native_priority_file"
+  return 1
+}
 
 base64url() {
   /usr/bin/openssl base64 -A | /usr/bin/tr '+/' '-_' | /usr/bin/tr -d '='
@@ -447,6 +459,11 @@ main() {
       continue
     fi
     if repository=$(next_repository); then
+      if native_lane_priority_requested; then
+        log "yielding the shared Tart lane to the waiting native controller"
+        /bin/sleep 15
+        continue
+      fi
       if run_one_ephemeral_runner "$repository"; then
         log "ephemeral runner cycle completed for ${repository}"
       else
@@ -461,4 +478,6 @@ main() {
   done
 }
 
-main
+if [[ "${TRIPS_RUNNER_CONTROLLER_TEST_MODE:-false}" != true ]]; then
+  main
+fi

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -61,6 +61,23 @@ shared_lane_has_ephemeral_vm() {
   printf '%s\n' "$vm_list" | /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
 }
 
+clone_artifact_result() {
+  local vm_name="$1" list_status="$2" vm_list="$3"
+  (( list_status == 0 )) || return 3
+  if printf '%s\n' "$vm_list" | /usr/bin/grep -qx "$vm_name"; then
+    log "clone failed after creating ${vm_name}; exiting for startup reconciliation"
+    return 3
+  fi
+  return 1
+}
+
+failed_clone_result() {
+  local vm_name="$1" vm_list list_status
+  vm_list=$(/opt/homebrew/bin/tart list --source local --quiet)
+  list_status=$?
+  clone_artifact_result "$vm_name" "$list_status" "$vm_list"
+}
+
 acquire_clean_lane_lock() {
   acquire_lane_lock || return 1
   if shared_lane_has_ephemeral_vm; then
@@ -322,7 +339,8 @@ run_one_ephemeral_runner() {
   /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || {
     release_lane_lock
     lane_lock_owned=false
-    return 1
+    failed_clone_result "$vm_name"
+    return $?
   }
 
   cleanup_vm() {
@@ -376,7 +394,7 @@ run_one_ephemeral_runner() {
       "admin@${vm_ip}" \
       "IFS= read -r registration_token; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work _work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || {
         cleanup_allowed=false
-        return 1
+        return 3
       }
     runner_claimed=false
     for _ in {1..150}; do
@@ -437,7 +455,8 @@ run_one_ephemeral_runner() {
     trap - INT TERM
     if ! cleanup_vm; then
       cleanup_allowed=false
-      runner_status=1
+      log "VM cleanup failed; exiting for startup reconciliation"
+      exit 1
     fi
     if [[ "$cleanup_allowed" == true && -n "$vm_pid" ]]; then
       wait "$vm_pid" >/dev/null 2>&1 || true

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -69,7 +69,7 @@ repository_has_queued_job() {
     /opt/homebrew/bin/gh api \
       -H 'Accept: application/vnd.github+json' \
       -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "repos/${repository}/actions/runs?per_page=30" \
+      "repos/${repository}/actions/runs?per_page=20" \
       --jq '.workflow_runs[] | select(.status == "queued" or .status == "in_progress") | .id'
   ) || return 1
 
@@ -338,9 +338,10 @@ main() {
         /bin/sleep 15
       fi
     else
-      # Eight repositories are inspected per pass. A 30-second cadence keeps
-      # idle discovery prompt without exhausting the user API allowance.
-      /bin/sleep 30
+      # At most 168 REST reads are made per full pass (eight repositories,
+      # one run list and up to twenty active-run job lists each). A three-minute
+      # idle cadence leaves API headroom while keeping discovery below five minutes.
+      /bin/sleep 180
     fi
   done
 }

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -18,6 +18,7 @@ readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
 readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
 readonly native_priority_file="${TRIPS_TART_NATIVE_PRIORITY_FILE:-/Users/jai/Library/Logs/trips-tart-runner-native-priority}"
+readonly lane_poll_seconds="${TRIPS_TART_LANE_POLL_SECONDS:-15}"
 
 typeset -g github_installation_token=""
 typeset -g github_installation_token_expires_at=0
@@ -35,19 +36,7 @@ log() {
 }
 
 acquire_lock() {
-  local lock_path="$1" owner_pid="" candidate
-  candidate="${lock_path}.$$"
-  printf '%s\n' $$ >"$candidate"
-  if /bin/ln "$candidate" "$lock_path" 2>/dev/null; then
-    /bin/rm -f "$candidate"
-    return 0
-  fi
-  /bin/rm -f "$candidate"
-  [[ -r "$lock_path" ]] || return 1
-  read -r owner_pid <"$lock_path"
-  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then return 1; fi
-  /bin/rm -f "$lock_path"
-  acquire_lock "$lock_path"
+  /usr/bin/shlock -f "$1" -p $$
 }
 
 release_lock() {
@@ -70,6 +59,21 @@ native_lane_priority_requested() {
   fi
   /bin/rm -f "$native_priority_file"
   return 1
+}
+
+acquire_linux_lane() {
+  while true; do
+    native_lane_priority_requested && return 2
+    if acquire_lane_lock; then
+      if native_lane_priority_requested; then
+        release_lane_lock
+        return 2
+      fi
+      return 0
+    fi
+    log "waiting because another Tart job VM is active"
+    /bin/sleep "$lane_poll_seconds"
+  done
 }
 
 base64url() {
@@ -253,7 +257,7 @@ delete_runner_registration() {
 }
 
 run_one_ephemeral_runner() {
-  local repository="$1" suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed ssh_ready state missing_count cleanup_allowed registration_state lane_lock_owned
+  local repository="$1" suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed ssh_ready state missing_count cleanup_allowed registration_state lane_lock_owned lane_result
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-linux-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
@@ -263,10 +267,10 @@ run_one_ephemeral_runner() {
   cleanup_allowed=true
   lane_lock_owned=false
 
-  while ! acquire_lane_lock; do
-    log "waiting because another Tart job VM is active"
-    /bin/sleep 15
-  done
+  acquire_linux_lane
+  lane_result=$?
+  (( lane_result == 2 )) && return 2
+  (( lane_result == 0 )) || return 1
   lane_lock_owned=true
 
   log "cloning ${base_vm} to ${vm_name} for ${repository}"
@@ -392,7 +396,7 @@ run_one_ephemeral_runner() {
 }
 
 main() {
-  local repository stale_ip stale_state preserved_stale=false
+  local repository runner_result stale_ip stale_state preserved_stale=false
   umask 077
   if ! acquire_controller_lock; then
     log "another Linux runner controller owns ${lock_directory}"
@@ -459,17 +463,19 @@ main() {
       continue
     fi
     if repository=$(next_repository); then
-      if native_lane_priority_requested; then
-        log "yielding the shared Tart lane to the waiting native controller"
-        /bin/sleep 15
-        continue
-      fi
-      if run_one_ephemeral_runner "$repository"; then
-        log "ephemeral runner cycle completed for ${repository}"
-      else
-        log "ephemeral runner cycle failed for ${repository}; retrying in 15 seconds"
-        /bin/sleep 15
-      fi
+      run_one_ephemeral_runner "$repository"
+      runner_result=$?
+      case "$runner_result" in
+        0) log "ephemeral runner cycle completed for ${repository}" ;;
+        2)
+          log "yielding the shared Tart lane to the waiting native controller"
+          /bin/sleep "$lane_poll_seconds"
+          ;;
+        *)
+          log "ephemeral runner cycle failed for ${repository}; retrying in 15 seconds"
+          /bin/sleep 15
+          ;;
+      esac
     else
       # Server-side status filters avoid losing active runs behind completed runs.
       # A pass costs at most 336 requests, preserving at least 1,164 in reserve.

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -245,13 +245,14 @@ run_one_ephemeral_runner() {
     for _ in {1..150}; do
       if runner_worker_started "$vm_ip"; then
         runner_claimed=true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-        runner_pid=""
         if wait_for_runner_shutdown "$vm_ip"; then
           runner_status=0
         else
           runner_status=1
         fi
+        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+        runner_pid=""
         break
       fi
       if [[ -n "$runner_pid" ]] && ! /bin/kill -0 "$runner_pid" 2>/dev/null; then
@@ -268,13 +269,16 @@ run_one_ephemeral_runner() {
     # not killed without observing its worker.
     if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
       runner_claimed=true
-      [[ -z "$runner_pid" ]] || wait "$runner_pid" >/dev/null 2>&1 || true
-      runner_pid=""
       if wait_for_runner_shutdown "$vm_ip"; then
         runner_status=0
       else
         runner_status=1
       fi
+      if [[ -n "$runner_pid" ]]; then
+        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+      fi
+      runner_pid=""
     fi
     if [[ "$runner_claimed" == false ]]; then
       log "${runner_name} remained idle; removing it"

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -283,6 +283,17 @@ wait_for_runner_shutdown() {
   fi
 }
 
+supervise_claimed_runner() {
+  local vm_ip="$1" state
+  wait_for_runner_shutdown "$vm_ip" && return 0
+  state=$(runner_process_state "$vm_ip")
+  if [[ "$state" != absent ]]; then
+    log "preserving claimed runner after supervision ended; live state is ${state}"
+    cleanup_allowed=false
+  fi
+  return 1
+}
+
 delete_runner_registration() {
   local repository="$1" runner_name="$2" id
   id=$(runner_id "$repository" "$runner_name") || return 0
@@ -372,7 +383,7 @@ run_one_ephemeral_runner() {
       state=$(runner_process_state "$vm_ip")
       if [[ "$state" == worker ]]; then
         runner_claimed=true
-        if wait_for_runner_shutdown "$vm_ip"; then
+        if supervise_claimed_runner "$vm_ip"; then
           runner_status=0
         else
           runner_status=1
@@ -401,12 +412,12 @@ run_one_ephemeral_runner() {
         /bin/sleep 5
       done
       if [[ "$runner_claimed" == true ]]; then
-        wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+        supervise_claimed_runner "$vm_ip" && runner_status=0 || runner_status=1
       elif (( missing_count >= 6 )); then
         registration_state=$(runner_registration_state "$repository" "$runner_name")
         if [[ "$registration_state" == busy ]]; then
           runner_claimed=true
-          wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+          supervise_claimed_runner "$vm_ip" && runner_status=0 || runner_status=1
         elif [[ "$registration_state" == idle || "$registration_state" == missing ]]; then
           log "${runner_name} drained without accepting a job; removing it"
           delete_runner_registration "$repository" "$runner_name" || true
@@ -424,7 +435,10 @@ run_one_ephemeral_runner() {
     fi
   } always {
     trap - INT TERM
-    cleanup_vm || runner_status=1
+    if ! cleanup_vm; then
+      cleanup_allowed=false
+      runner_status=1
+    fi
     if [[ "$cleanup_allowed" == true && -n "$vm_pid" ]]; then
       wait "$vm_pid" >/dev/null 2>&1 || true
     fi

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -116,13 +116,13 @@ registration_token() {
 }
 
 repository_has_queued_job() {
-  local repository="$1" run_id run_ids queued_job_count status
+  local repository="$1" run_id run_ids queued_job_count run_status
   run_ids=""
-  for status in queued in_progress; do
+  for run_status in queued in_progress; do
     run_ids+=$(/opt/homebrew/bin/gh api \
       -H 'Accept: application/vnd.github+json' \
       -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "repos/${repository}/actions/runs?status=${status}&per_page=20" \
+      "repos/${repository}/actions/runs?status=${run_status}&per_page=20" \
       --jq '.workflow_runs[].id') || return 1
     run_ids+=$'\n'
   done

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -109,25 +109,37 @@ registration_token() {
 }
 
 repository_has_queued_job() {
-  local repository="$1" run_id run_ids queued_job_count status response
+  local repository="$1" run_id run_ids queued_job_count status
   run_ids=""
   for status in queued in_progress; do
-    response=$(github_api GET "repos/${repository}/actions/runs?status=${status}&per_page=100") || return 1
-    run_ids+=$(printf '%s' "$response" | /usr/bin/python3 -c 'import json,sys; print("\n".join(str(run["id"]) for run in json.load(sys.stdin)["workflow_runs"]))') || return 1
+    run_ids+=$(/opt/homebrew/bin/gh api \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "repos/${repository}/actions/runs?status=${status}&per_page=20" \
+      --jq '.workflow_runs[].id') || return 1
     run_ids+=$'\n'
   done
 
   while IFS= read -r run_id; do
     [[ -n "$run_id" ]] || continue
     queued_job_count=$(
-      github_api GET "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
-        /usr/bin/python3 -c 'import json,sys; print(sum(1 for job in json.load(sys.stdin)["jobs"] if job["status"] == "queued" and all(label in job["labels"] for label in ("self-hosted", "linux", "arm64", "jai-ci"))))'
+      /opt/homebrew/bin/gh api \
+        -H 'Accept: application/vnd.github+json' \
+        -H 'X-GitHub-Api-Version: 2022-11-28' \
+        "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
+        --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length'
     ) || continue
     if [[ "$queued_job_count" == <1-> ]]; then
       return 0
     fi
   done <<<"$run_ids"
   return 1
+}
+
+user_api_has_headroom() {
+  local remaining
+  remaining=$(/opt/homebrew/bin/gh api rate_limit --jq '.resources.core.remaining') || return 1
+  [[ "$remaining" == <1000-> ]]
 }
 
 next_repository() {
@@ -369,6 +381,10 @@ main() {
     log "GitHub App authentication is unavailable"
     return 1
   fi
+  if ! /opt/homebrew/bin/gh auth token >/dev/null 2>&1; then
+    log "GitHub CLI authentication is unavailable for private-repository queue discovery"
+    return 1
+  fi
 
   while IFS= read -r stale_vm; do
     if [[ "$stale_vm" == trips-linux-runner-job-* ]]; then
@@ -387,8 +403,8 @@ main() {
   [[ "$preserved_stale" == false ]] || return 1
 
   while true; do
-    if ! ensure_installation_token; then
-      log "GitHub App token refresh failed; retrying in 180 seconds"
+    if ! user_api_has_headroom; then
+      log "GitHub user API has less than 1,000 core requests remaining; pausing discovery for 180 seconds"
       /bin/sleep 180
       continue
     fi
@@ -400,9 +416,8 @@ main() {
         /bin/sleep 15
       fi
     else
-      # At most 168 REST reads are made per full pass (eight repositories,
-      # one run list and up to twenty active-run job lists each). A three-minute
-      # idle cadence leaves API headroom while keeping discovery below five minutes.
+      # Server-side status filters avoid losing active runs behind completed runs.
+      # Discovery stops with 1,000 requests in reserve and idles between passes.
       /bin/sleep 180
     fi
   done

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -15,6 +15,10 @@ readonly private_key="/Users/jai/.config/trips-tart-runner/github-app-private-ke
 readonly ssh_key="/Users/jai/.config/trips-tart-runner/runner-controller-ed25519"
 readonly log_directory="/Users/jai/Library/Logs/trips-linux-tart-runner"
 readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
+readonly lock_directory="${log_directory}/controller.lock"
+
+typeset -g github_installation_token=""
+typeset -g github_installation_token_expires_at=0
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
@@ -26,6 +30,27 @@ timestamp() {
 
 log() {
   print -r -- "$(timestamp) $*"
+}
+
+acquire_controller_lock() {
+  local owner_pid=""
+  if /bin/mkdir "$lock_directory" 2>/dev/null; then
+    printf '%s\n' $$ >"${lock_directory}/owner.pid"
+    return 0
+  fi
+  [[ -r "${lock_directory}/owner.pid" ]] && read -r owner_pid <"${lock_directory}/owner.pid"
+  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
+    return 1
+  fi
+  /bin/rm -f "${lock_directory}/owner.pid"
+  /bin/rmdir "$lock_directory" 2>/dev/null || return 1
+  /bin/mkdir "$lock_directory" 2>/dev/null || return 1
+  printf '%s\n' $$ >"${lock_directory}/owner.pid"
+}
+
+release_controller_lock() {
+  /bin/rm -f "${lock_directory}/owner.pid"
+  /bin/rmdir "$lock_directory" >/dev/null 2>&1 || true
 }
 
 base64url() {
@@ -44,19 +69,39 @@ github_jwt() {
   printf '%s.%s' "$unsigned" "$signature"
 }
 
-registration_token() {
-  local repository="$1" jwt installation_token
+ensure_installation_token() {
+  local jwt now response
+  now=$(/bin/date +%s)
+  if [[ -n "$github_installation_token" ]] && (( now < github_installation_token_expires_at )); then
+    return 0
+  fi
   jwt=$(github_jwt) || return 1
-  installation_token=$(
+  response=$(
     /usr/bin/curl -fsS -X POST \
       -H "Authorization: Bearer $jwt" \
       -H 'Accept: application/vnd.github+json' \
       -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "https://api.github.com/app/installations/${installation_id}/access_tokens" |
-      /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+      "https://api.github.com/app/installations/${installation_id}/access_tokens"
   ) || return 1
+  github_installation_token=$(printf '%s' "$response" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])') || return 1
+  github_installation_token_expires_at=$(( now + 3000 ))
+}
+
+github_api() {
+  local method="$1" endpoint="$2"
+  ensure_installation_token || return 1
+  /usr/bin/curl -fsS -X "$method" \
+    -H "Authorization: Bearer $github_installation_token" \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "https://api.github.com/${endpoint}"
+}
+
+registration_token() {
+  local repository="$1"
+  ensure_installation_token || return 1
   /usr/bin/curl -fsS -X POST \
-    -H "Authorization: Bearer $installation_token" \
+    -H "Authorization: Bearer $github_installation_token" \
     -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "https://api.github.com/repos/${repository}/actions/runners/registration-token" |
@@ -64,23 +109,19 @@ registration_token() {
 }
 
 repository_has_queued_job() {
-  local repository="$1" run_id run_ids queued_job_count
-  run_ids=$(
-    /opt/homebrew/bin/gh api \
-      -H 'Accept: application/vnd.github+json' \
-      -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "repos/${repository}/actions/runs?per_page=20" \
-      --jq '.workflow_runs[] | select(.status == "queued" or .status == "in_progress") | .id'
-  ) || return 1
+  local repository="$1" run_id run_ids queued_job_count status response
+  run_ids=""
+  for status in queued in_progress; do
+    response=$(github_api GET "repos/${repository}/actions/runs?status=${status}&per_page=100") || return 1
+    run_ids+=$(printf '%s' "$response" | /usr/bin/python3 -c 'import json,sys; print("\n".join(str(run["id"]) for run in json.load(sys.stdin)["workflow_runs"]))') || return 1
+    run_ids+=$'\n'
+  done
 
   while IFS= read -r run_id; do
     [[ -n "$run_id" ]] || continue
     queued_job_count=$(
-      /opt/homebrew/bin/gh api \
-      -H 'Accept: application/vnd.github+json' \
-      -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
-      --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length'
+      github_api GET "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
+        /usr/bin/python3 -c 'import json,sys; print(sum(1 for job in json.load(sys.stdin)["jobs"] if job["status"] == "queued" and all(label in job["labels"] for label in ("self-hosted", "linux", "arm64", "jai-ci"))))'
     ) || continue
     if [[ "$queued_job_count" == <1-> ]]; then
       return 0
@@ -108,16 +149,14 @@ delete_vm() {
 
 runner_id() {
   local repository="$1" runner_name="$2"
-  /opt/homebrew/bin/gh api \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2022-11-28' \
-    "repos/${repository}/actions/runners?per_page=100" \
-    --jq ".runners[] | select(.name == \"${runner_name}\") | .id"
+  github_api GET "repos/${repository}/actions/runners?per_page=100" |
+    RUNNER_NAME="$runner_name" /usr/bin/python3 -c 'import json,os,sys; print(next((runner["id"] for runner in json.load(sys.stdin)["runners"] if runner["name"] == os.environ["RUNNER_NAME"]), ""))'
 }
 
-runner_worker_started() {
+runner_process_state() {
   local vm_ip="$1"
-  /usr/bin/ssh \
+  local state
+  state=$(/usr/bin/ssh \
     -o BatchMode=yes \
     -o ConnectTimeout=3 \
     -o ServerAliveInterval=2 \
@@ -126,32 +165,36 @@ runner_worker_started() {
     -o UserKnownHostsFile=/dev/null \
     -i "$ssh_key" \
     "admin@${vm_ip}" \
-    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null" 2>/dev/null
+    "if /usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null; then printf '%s\\n' worker; elif /usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' >/dev/null; then printf '%s\\n' listener; else printf '%s\\n' absent; fi" 2>/dev/null) || {
+    print unreachable
+    return 0
+  }
+  print -r -- "$state"
 }
 
-runner_listener_started() {
-  local vm_ip="$1"
-  /usr/bin/ssh \
-    -o BatchMode=yes \
-    -o ConnectTimeout=3 \
-    -o ServerAliveInterval=2 \
-    -o ServerAliveCountMax=2 \
-    -o StrictHostKeyChecking=no \
-    -o UserKnownHostsFile=/dev/null \
-    -i "$ssh_key" \
+stop_idle_listener() {
+  local vm_ip="$1" state
+  state=$(/usr/bin/ssh \
+    -o BatchMode=yes -o ConnectTimeout=3 -o ServerAliveInterval=2 -o ServerAliveCountMax=2 \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$ssh_key" \
     "admin@${vm_ip}" \
-    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' >/dev/null" 2>/dev/null
+    "if /usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null; then printf '%s\\n' worker; else listener_pid=\$(/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' | /usr/bin/head -n 1); if [[ -n \"\$listener_pid\" ]]; then /bin/kill -TERM \"\$listener_pid\"; printf '%s\\n' draining; else printf '%s\\n' absent; fi; fi" 2>/dev/null) || {
+    print unreachable
+    return 0
+  }
+  print -r -- "$state"
 }
 
 wait_for_runner_shutdown() {
-  local vm_ip="$1" missing_count=0 deadline
+  local vm_ip="$1" missing_count=0 deadline state
   deadline=$(( $(/bin/date +%s) + 3300 ))
   while (( missing_count < 3 && $(/bin/date +%s) < deadline )); do
-    if runner_worker_started "$vm_ip" || runner_listener_started "$vm_ip"; then
-      missing_count=0
-    else
-      (( missing_count += 1 ))
-    fi
+    state=$(runner_process_state "$vm_ip")
+    case "$state" in
+      worker|listener) missing_count=0 ;;
+      absent) (( missing_count += 1 )) ;;
+      unreachable) log "runner probe could not reach ${vm_ip}; preserving execution" ;;
+    esac
     (( missing_count >= 3 )) || /bin/sleep 5
   done
   if (( missing_count < 3 )); then
@@ -164,21 +207,18 @@ delete_runner_registration() {
   local repository="$1" runner_name="$2" id
   id=$(runner_id "$repository" "$runner_name") || return 0
   [[ -n "$id" ]] || return 0
-  /opt/homebrew/bin/gh api --method DELETE \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2022-11-28' \
-    "repos/${repository}/actions/runners/${id}" >/dev/null
+  github_api DELETE "repos/${repository}/actions/runners/${id}" >/dev/null
 }
 
 run_one_ephemeral_runner() {
-  local repository="$1" suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_pid runner_claimed ssh_ready ios_runner_count linux_runner_count
+  local repository="$1" suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed ssh_ready ios_runner_count linux_runner_count state missing_count cleanup_allowed
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-linux-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
   vm_log="${log_directory}/${vm_name}.log"
   vm_pid=""
-  runner_pid=""
   runner_status=1
+  cleanup_allowed=true
 
   while true; do
     ios_runner_count=$(
@@ -189,8 +229,8 @@ run_one_ephemeral_runner() {
       /opt/homebrew/bin/tart list --source local --quiet |
         /usr/bin/grep -c '^trips-linux-runner-job-' || true
     )
-    (( ios_runner_count == 0 || linux_runner_count == 0 )) && break
-    log "waiting because an iOS VM and a Linux runner are already active"
+    (( ios_runner_count == 0 && linux_runner_count == 0 )) && break
+    log "waiting because another Tart job VM is active"
     /bin/sleep 15
   done
 
@@ -198,6 +238,10 @@ run_one_ephemeral_runner() {
   /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || return 1
 
   cleanup_vm() {
+    if [[ "$cleanup_allowed" != true ]]; then
+      log "preserving ${vm_name} because safe shutdown was not proven"
+      return 0
+    fi
     log "deleting ${vm_name}"
     delete_vm "$vm_name"
   }
@@ -239,56 +283,51 @@ run_one_ephemeral_runner() {
       -o UserKnownHostsFile=/dev/null \
       -i "$ssh_key" \
       "admin@${vm_ip}" \
-      "IFS= read -r registration_token; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work _work; exec ./run.sh" &
-    runner_pid=$!
+      "IFS= read -r registration_token; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work _work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || return 1
     runner_claimed=false
     for _ in {1..150}; do
-      if runner_worker_started "$vm_ip"; then
+      state=$(runner_process_state "$vm_ip")
+      if [[ "$state" == worker ]]; then
         runner_claimed=true
         if wait_for_runner_shutdown "$vm_ip"; then
           runner_status=0
         else
           runner_status=1
         fi
-        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-        runner_pid=""
         break
-      fi
-      if [[ -n "$runner_pid" ]] && ! /bin/kill -0 "$runner_pid" 2>/dev/null; then
-        wait "$runner_pid"
-        runner_status=$?
-        runner_pid=""
-        if ! runner_listener_started "$vm_ip"; then
-          break
-        fi
       fi
       /bin/sleep 2
     done
-    # Recheck after the final sleep so a job accepted at the idle deadline is
-    # not killed without observing its worker.
-    if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
-      runner_claimed=true
-      if wait_for_runner_shutdown "$vm_ip"; then
+    if [[ "$runner_claimed" == false ]]; then
+      state=$(stop_idle_listener "$vm_ip")
+      missing_count=0
+      for _ in {1..24}; do
+        state=$(runner_process_state "$vm_ip")
+        if [[ "$state" == worker ]]; then
+          runner_claimed=true
+          break
+        elif [[ "$state" == absent ]]; then
+          (( missing_count += 1 ))
+          (( missing_count >= 3 )) && break
+        elif [[ "$state" == listener ]]; then
+          stop_idle_listener "$vm_ip" >/dev/null
+          missing_count=0
+        else
+          missing_count=0
+        fi
+        /bin/sleep 5
+      done
+      if [[ "$runner_claimed" == true ]]; then
+        wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+      elif (( missing_count >= 3 )); then
+        log "${runner_name} drained without accepting a job; removing it"
+        delete_runner_registration "$repository" "$runner_name" || true
         runner_status=0
       else
+        log "could not prove ${runner_name} idle after draining"
+        cleanup_allowed=false
         runner_status=1
       fi
-      if [[ -n "$runner_pid" ]]; then
-        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-      fi
-      runner_pid=""
-    fi
-    if [[ "$runner_claimed" == false ]]; then
-      log "${runner_name} remained idle; removing it"
-      if [[ -n "$runner_pid" ]]; then
-        /bin/kill "$runner_pid" 2>/dev/null || true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-      fi
-      runner_pid=""
-      delete_runner_registration "$repository" "$runner_name" || true
-      runner_status=0
     fi
   } always {
     trap - INT TERM
@@ -299,8 +338,13 @@ run_one_ephemeral_runner() {
 }
 
 main() {
-  local repository
+  local repository stale_ip stale_state preserved_stale=false
   umask 077
+  if ! acquire_controller_lock; then
+    log "another Linux runner controller owns ${lock_directory}"
+    return 0
+  fi
+  trap 'release_controller_lock' EXIT
   if [[ -n "$required_volume" ]] && ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
     log "required volume ${required_volume} is not mounted"
     return 1
@@ -321,19 +365,33 @@ main() {
     log "failed to set ${base_vm} memory to ${base_memory_mb} MB"
     return 1
   fi
-  if ! /opt/homebrew/bin/gh auth token >/dev/null 2>&1; then
-    log "GitHub CLI authentication is unavailable"
+  if ! ensure_installation_token; then
+    log "GitHub App authentication is unavailable"
     return 1
   fi
 
   while IFS= read -r stale_vm; do
     if [[ "$stale_vm" == trips-linux-runner-job-* ]]; then
-      log "removing stale ephemeral VM ${stale_vm}"
+      if stale_ip=$(/opt/homebrew/bin/tart ip "$stale_vm" 2>/dev/null); then
+        stale_state=$(runner_process_state "$stale_ip")
+        if [[ "$stale_state" != absent ]]; then
+          log "preserving ${stale_vm}; live state is ${stale_state}"
+          preserved_stale=true
+          continue
+        fi
+      fi
+      log "removing safely stopped stale ephemeral VM ${stale_vm}"
       delete_vm "$stale_vm"
     fi
   done < <(/opt/homebrew/bin/tart list --source local --quiet)
+  [[ "$preserved_stale" == false ]] || return 1
 
   while true; do
+    if ! ensure_installation_token; then
+      log "GitHub App token refresh failed; retrying in 180 seconds"
+      /bin/sleep 180
+      continue
+    fi
     if repository=$(next_repository); then
       if run_one_ephemeral_runner "$repository"; then
         log "ephemeral runner cycle completed for ${repository}"

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -255,6 +255,16 @@ stop_idle_listener() {
   print -r -- "$state"
 }
 
+reconcile_stale_runner_state() {
+  local vm_ip="$1" state="$2"
+  if [[ "$state" == listener ]]; then
+    state=$(stop_idle_listener "$vm_ip")
+    [[ "$state" != draining ]] || /bin/sleep 5
+    state=$(runner_process_state "$vm_ip")
+  fi
+  print -r -- "$state"
+}
+
 wait_for_runner_shutdown() {
   local vm_ip="$1" missing_count=0 deadline state
   deadline=$(( $(/bin/date +%s) + 3300 ))
@@ -464,6 +474,7 @@ main() {
     if [[ "$stale_vm" == trips-linux-runner-job-* ]]; then
       if stale_ip=$(/opt/homebrew/bin/tart ip "$stale_vm" 2>/dev/null); then
         stale_state=$(runner_process_state "$stale_ip")
+        stale_state=$(reconcile_stale_runner_state "$stale_ip" "$stale_state")
         if [[ "$stale_state" != absent ]]; then
           log "preserving ${stale_vm}; live state is ${stale_state}"
           preserved_stale=true

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -129,6 +129,37 @@ runner_worker_started() {
     "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null" 2>/dev/null
 }
 
+runner_listener_started() {
+  local vm_ip="$1"
+  /usr/bin/ssh \
+    -o BatchMode=yes \
+    -o ConnectTimeout=3 \
+    -o ServerAliveInterval=2 \
+    -o ServerAliveCountMax=2 \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "$ssh_key" \
+    "admin@${vm_ip}" \
+    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' >/dev/null" 2>/dev/null
+}
+
+wait_for_runner_shutdown() {
+  local vm_ip="$1" missing_count=0 deadline
+  deadline=$(( $(/bin/date +%s) + 3300 ))
+  while (( missing_count < 3 && $(/bin/date +%s) < deadline )); do
+    if runner_worker_started "$vm_ip" || runner_listener_started "$vm_ip"; then
+      missing_count=0
+    else
+      (( missing_count += 1 ))
+    fi
+    (( missing_count >= 3 )) || /bin/sleep 5
+  done
+  if (( missing_count < 3 )); then
+    log "runner processes exceeded the 55-minute execution budget"
+    return 1
+  fi
+}
+
 delete_runner_registration() {
   local repository="$1" runner_name="$2" id
   id=$(runner_id "$repository" "$runner_name") || return 0
@@ -212,21 +243,24 @@ run_one_ephemeral_runner() {
     runner_pid=$!
     runner_claimed=false
     for _ in {1..150}; do
-      if ! /bin/kill -0 "$runner_pid" 2>/dev/null; then
-        wait "$runner_pid"
-        runner_status=$?
-        runner_claimed=true
-        break
-      fi
-      # GitHub's runner busy flag can become true before the broker actually
-      # starts a job, and can remain stale when dispatch fails. Only the worker
-      # process proves this VM accepted executable work; otherwise keep the
-      # bounded idle timer running and recycle the runner after five minutes.
       if runner_worker_started "$vm_ip"; then
         runner_claimed=true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+        runner_pid=""
+        if wait_for_runner_shutdown "$vm_ip"; then
+          runner_status=0
+        else
+          runner_status=1
+        fi
+        break
+      fi
+      if [[ -n "$runner_pid" ]] && ! /bin/kill -0 "$runner_pid" 2>/dev/null; then
         wait "$runner_pid"
         runner_status=$?
-        break
+        runner_pid=""
+        if ! runner_listener_started "$vm_ip"; then
+          break
+        fi
       fi
       /bin/sleep 2
     done
@@ -234,13 +268,21 @@ run_one_ephemeral_runner() {
     # not killed without observing its worker.
     if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
       runner_claimed=true
-      wait "$runner_pid"
-      runner_status=$?
+      [[ -z "$runner_pid" ]] || wait "$runner_pid" >/dev/null 2>&1 || true
+      runner_pid=""
+      if wait_for_runner_shutdown "$vm_ip"; then
+        runner_status=0
+      else
+        runner_status=1
+      fi
     fi
     if [[ "$runner_claimed" == false ]]; then
       log "${runner_name} remained idle; removing it"
-      /bin/kill "$runner_pid" 2>/dev/null || true
-      wait "$runner_pid" >/dev/null 2>&1 || true
+      if [[ -n "$runner_pid" ]]; then
+        /bin/kill "$runner_pid" 2>/dev/null || true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+      fi
+      runner_pid=""
       delete_runner_registration "$repository" "$runner_name" || true
       runner_status=0
     fi

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -36,19 +36,7 @@ log() {
 }
 
 acquire_lock() {
-  local lock_path="$1" owner_pid="" candidate
-  candidate="${lock_path}.$$"
-  printf '%s\n' $$ >"$candidate"
-  if /bin/ln "$candidate" "$lock_path" 2>/dev/null; then
-    /bin/rm -f "$candidate"
-    return 0
-  fi
-  /bin/rm -f "$candidate"
-  [[ -r "$lock_path" ]] || return 1
-  read -r owner_pid <"$lock_path"
-  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then return 1; fi
-  /bin/rm -f "$lock_path"
-  acquire_lock "$lock_path"
+  /usr/bin/shlock -f "$1" -p $$
 }
 
 release_lock() {
@@ -427,7 +415,10 @@ main() {
   done
 
   while true; do
-    if repository_has_queued_native_job; then
+    if ! ensure_installation_token; then
+      log "GitHub App authentication is unavailable; retrying in 30 seconds"
+      /bin/sleep 30
+    elif repository_has_queued_native_job; then
       if run_one_ephemeral_runner; then
         log "ephemeral runner cycle completed"
       else

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -16,6 +16,10 @@ readonly ssh_key="/Users/jai/.config/trips-tart-runner/runner-controller-ed25519
 readonly log_directory="/Users/jai/Library/Logs/trips-tart-runner"
 readonly work_disk_directory="${TRIPS_TART_WORK_DISK_DIRECTORY:-/Users/jai/.local/share/trips-tart-runner/work-disks}"
 readonly required_volume="${TRIPS_TART_REQUIRED_VOLUME:-}"
+readonly lock_directory="${log_directory}/controller.lock"
+
+typeset -g github_installation_token=""
+typeset -g github_installation_token_expires_at=0
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
@@ -27,6 +31,27 @@ timestamp() {
 
 log() {
   print -r -- "$(timestamp) $*"
+}
+
+acquire_controller_lock() {
+  local owner_pid=""
+  if /bin/mkdir "$lock_directory" 2>/dev/null; then
+    printf '%s\n' $$ >"${lock_directory}/owner.pid"
+    return 0
+  fi
+  [[ -r "${lock_directory}/owner.pid" ]] && read -r owner_pid <"${lock_directory}/owner.pid"
+  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
+    return 1
+  fi
+  /bin/rm -f "${lock_directory}/owner.pid"
+  /bin/rmdir "$lock_directory" 2>/dev/null || return 1
+  /bin/mkdir "$lock_directory" 2>/dev/null || return 1
+  printf '%s\n' $$ >"${lock_directory}/owner.pid"
+}
+
+release_controller_lock() {
+  /bin/rm -f "${lock_directory}/owner.pid"
+  /bin/rmdir "$lock_directory" >/dev/null 2>&1 || true
 }
 
 base64url() {
@@ -45,19 +70,34 @@ github_jwt() {
   printf '%s.%s' "$unsigned" "$signature"
 }
 
-registration_token() {
-  local jwt installation_token
+ensure_installation_token() {
+  local jwt now response
+  now=$(/bin/date +%s)
+  if [[ -n "$github_installation_token" ]] && (( now < github_installation_token_expires_at )); then return 0; fi
   jwt=$(github_jwt) || return 1
-  installation_token=$(
+  response=$(
     /usr/bin/curl -fsS -X POST \
       -H "Authorization: Bearer $jwt" \
       -H 'Accept: application/vnd.github+json' \
       -H 'X-GitHub-Api-Version: 2022-11-28' \
-      "https://api.github.com/app/installations/${installation_id}/access_tokens" |
-      /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+      "https://api.github.com/app/installations/${installation_id}/access_tokens"
   ) || return 1
+  github_installation_token=$(printf '%s' "$response" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])') || return 1
+  github_installation_token_expires_at=$(( now + 3000 ))
+}
+
+github_api() {
+  local method="$1" endpoint="$2"
+  ensure_installation_token || return 1
+  /usr/bin/curl -fsS -X "$method" -H "Authorization: Bearer $github_installation_token" \
+    -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "https://api.github.com/${endpoint}"
+}
+
+registration_token() {
+  ensure_installation_token || return 1
   /usr/bin/curl -fsS -X POST \
-    -H "Authorization: Bearer $installation_token" \
+    -H "Authorization: Bearer $github_installation_token" \
     -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "https://api.github.com/repos/${repository}/actions/runners/registration-token" |
@@ -70,9 +110,10 @@ delete_vm() {
   /opt/homebrew/bin/tart delete "$vm_name" >/dev/null 2>&1 || true
 }
 
-runner_worker_started() {
+runner_process_state() {
   local vm_ip="$1"
-  /usr/bin/ssh \
+  local state
+  state=$(/usr/bin/ssh \
     -o BatchMode=yes \
     -o ConnectTimeout=3 \
     -o ServerAliveInterval=2 \
@@ -81,12 +122,17 @@ runner_worker_started() {
     -o UserKnownHostsFile=/dev/null \
     -i "$ssh_key" \
     "admin@${vm_ip}" \
-    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null" 2>/dev/null
+    "if /usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null; then printf '%s\\n' worker; elif /usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' >/dev/null; then printf '%s\\n' listener; else printf '%s\\n' absent; fi" 2>/dev/null) || {
+    print unreachable
+    return 0
+  }
+  print -r -- "$state"
 }
 
-runner_listener_started() {
+stop_idle_listener() {
   local vm_ip="$1"
-  /usr/bin/ssh \
+  local state
+  state=$(/usr/bin/ssh \
     -o BatchMode=yes \
     -o ConnectTimeout=3 \
     -o ServerAliveInterval=2 \
@@ -95,18 +141,23 @@ runner_listener_started() {
     -o UserKnownHostsFile=/dev/null \
     -i "$ssh_key" \
     "admin@${vm_ip}" \
-    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' >/dev/null" 2>/dev/null
+    "if /usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null; then printf '%s\\n' worker; else listener_pid=\$(/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' | /usr/bin/head -n 1); if [[ -n \"\$listener_pid\" ]]; then /bin/kill -TERM \"\$listener_pid\"; printf '%s\\n' draining; else printf '%s\\n' absent; fi; fi" 2>/dev/null) || {
+    print unreachable
+    return 0
+  }
+  print -r -- "$state"
 }
 
 wait_for_runner_shutdown() {
-  local vm_ip="$1" missing_count=0 deadline
+  local vm_ip="$1" missing_count=0 deadline state
   deadline=$(( $(/bin/date +%s) + 3300 ))
   while (( missing_count < 3 && $(/bin/date +%s) < deadline )); do
-    if runner_worker_started "$vm_ip" || runner_listener_started "$vm_ip"; then
-      missing_count=0
-    else
-      (( missing_count += 1 ))
-    fi
+    state=$(runner_process_state "$vm_ip")
+    case "$state" in
+      worker|listener) missing_count=0 ;;
+      absent) (( missing_count += 1 )) ;;
+      unreachable) log "runner probe could not reach ${vm_ip}; preserving execution" ;;
+    esac
     (( missing_count >= 3 )) || /bin/sleep 5
   done
   if (( missing_count < 3 )); then
@@ -115,24 +166,36 @@ wait_for_runner_shutdown() {
   fi
 }
 
+delete_runner_registration() {
+  local runner_name="$1" id
+  id=$(github_api GET "repos/${repository}/actions/runners?per_page=100" |
+    RUNNER_NAME="$runner_name" /usr/bin/python3 -c 'import json,os,sys; print(next((runner["id"] for runner in json.load(sys.stdin)["runners"] if runner["name"] == os.environ["RUNNER_NAME"]), ""))') || return 0
+  [[ -n "$id" ]] || return 0
+  github_api DELETE "repos/${repository}/actions/runners/${id}" >/dev/null
+}
+
 run_one_ephemeral_runner() {
-  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_pid runner_claimed work_disk ssh_ready linux_runner_count
+  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed work_disk ssh_ready linux_runner_count ios_runner_count state missing_count cleanup_allowed
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
   vm_log="${log_directory}/${vm_name}.log"
   work_disk="${work_disk_directory}/${vm_name}.raw"
   vm_pid=""
-  runner_pid=""
   runner_status=1
+  cleanup_allowed=true
 
   while true; do
     linux_runner_count=$(
       /opt/homebrew/bin/tart list --source local --quiet |
         /usr/bin/grep -c '^trips-linux-runner-job-' || true
     )
-    (( linux_runner_count <= 1 )) && break
-    log "waiting for Linux runner count to drop below two"
+    ios_runner_count=$(
+      /opt/homebrew/bin/tart list --source local --quiet |
+        /usr/bin/grep -c '^trips-runner-job-' || true
+    )
+    (( linux_runner_count == 0 && ios_runner_count == 0 )) && break
+    log "waiting because another Tart job VM is active"
     /bin/sleep 15
   done
 
@@ -140,6 +203,10 @@ run_one_ephemeral_runner() {
   /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || return 1
 
   cleanup_vm() {
+    if [[ "$cleanup_allowed" != true ]]; then
+      log "preserving ${vm_name} because safe shutdown was not proven"
+      return 0
+    fi
     log "deleting ${vm_name}"
     delete_vm "$vm_name"
     /bin/rm -f "$work_disk"
@@ -192,57 +259,45 @@ run_one_ephemeral_runner() {
       -o UserKnownHostsFile=/dev/null \
       -i "$ssh_key" \
       "admin@${vm_ip}" \
-      "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; exec ./run.sh" &
-    runner_pid=$!
+      "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || return 1
     runner_claimed=false
 
     for _ in {1..60}; do
-      if runner_worker_started "$vm_ip"; then
+      state=$(runner_process_state "$vm_ip")
+      if [[ "$state" == worker ]]; then
         runner_claimed=true
         if wait_for_runner_shutdown "$vm_ip"; then
           runner_status=0
         else
           runner_status=1
         fi
-        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-        runner_pid=""
         break
-      fi
-      if [[ -n "$runner_pid" ]] && ! /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
-        wait "$runner_pid"
-        runner_status=$?
-        runner_pid=""
-        if ! runner_listener_started "$vm_ip"; then
-          break
-        fi
       fi
       /bin/sleep 5
     done
-
-    # Recheck after the final sleep so a job accepted at the idle deadline is
-    # not killed without observing its worker.
-    if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
-      runner_claimed=true
-      if wait_for_runner_shutdown "$vm_ip"; then
+    if [[ "$runner_claimed" == false ]]; then
+      state=$(stop_idle_listener "$vm_ip")
+      missing_count=0
+      for _ in {1..24}; do
+        state=$(runner_process_state "$vm_ip")
+        if [[ "$state" == worker ]]; then runner_claimed=true; break
+        elif [[ "$state" == absent ]]; then (( missing_count += 1 )); (( missing_count >= 3 )) && break
+        elif [[ "$state" == listener ]]; then stop_idle_listener "$vm_ip" >/dev/null; missing_count=0
+        else missing_count=0
+        fi
+        /bin/sleep 5
+      done
+      if [[ "$runner_claimed" == true ]]; then
+        wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+      elif (( missing_count >= 3 )); then
+        log "${runner_name} drained without accepting a job; removing it"
+        delete_runner_registration "$runner_name" || true
         runner_status=0
       else
+        log "could not prove ${runner_name} idle after draining"
+        cleanup_allowed=false
         runner_status=1
       fi
-      if [[ -n "$runner_pid" ]]; then
-        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-      fi
-      runner_pid=""
-    fi
-    if [[ "$runner_claimed" == false ]]; then
-      log "${runner_name} remained idle; removing it"
-      if [[ -n "$runner_pid" ]]; then
-        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-      fi
-      runner_pid=""
-      runner_status=0
     fi
   } always {
     trap - INT TERM
@@ -253,7 +308,13 @@ run_one_ephemeral_runner() {
 }
 
 main() {
+  local stale_ip stale_state preserved_stale=false
   umask 077
+  if ! acquire_controller_lock; then
+    log "another iOS runner controller owns ${lock_directory}"
+    return 0
+  fi
+  trap 'release_controller_lock' EXIT
   if [[ -n "$required_volume" ]] && ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
     log "required volume ${required_volume} is not mounted"
     return 1
@@ -270,10 +331,19 @@ main() {
 
   while IFS= read -r stale_vm; do
     if [[ "$stale_vm" == trips-runner-job-* ]]; then
-      log "removing stale ephemeral VM ${stale_vm}"
+      if stale_ip=$(/opt/homebrew/bin/tart ip "$stale_vm" 2>/dev/null); then
+        stale_state=$(runner_process_state "$stale_ip")
+        if [[ "$stale_state" != absent ]]; then
+          log "preserving ${stale_vm}; live state is ${stale_state}"
+          preserved_stale=true
+          continue
+        fi
+      fi
+      log "removing safely stopped stale ephemeral VM ${stale_vm}"
       delete_vm "$stale_vm"
     fi
   done < <(/opt/homebrew/bin/tart list --source local --quiet)
+  [[ "$preserved_stale" == false ]] || return 1
   for stale_disk in "${work_disk_directory}"/trips-runner-job-*.raw(N); do
     log "removing stale ephemeral work disk ${stale_disk:t}"
     /bin/rm -f "$stale_disk"
@@ -281,7 +351,7 @@ main() {
 
   while true; do
     if run_one_ephemeral_runner; then
-      log "ephemeral runner completed a job"
+      log "ephemeral runner cycle completed"
     else
       log "ephemeral runner cycle failed; retrying in 30 seconds"
       /bin/sleep 30

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -153,7 +153,7 @@ repository_has_queued_native_job() {
   while IFS= read -r run_id; do
     [[ -n "$run_id" ]] || continue
     queued_job_count=$(github_api GET "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
-      /usr/bin/python3 -c 'import json,sys; required={"self-hosted","macOS","ARM64","tart","ios"}; print(sum(job["status"] == "queued" and required.issubset(job["labels"]) for job in json.load(sys.stdin)["jobs"]))') || continue
+      AVAILABLE_LABELS="self-hosted,macOS,ARM64,${runner_labels}" /usr/bin/python3 -c 'import json,os,sys; available=set(os.environ["AVAILABLE_LABELS"].split(",")); print(sum(job["status"] == "queued" and set(job["labels"]).issubset(available) for job in json.load(sys.stdin)["jobs"]))') || continue
     if [[ "$queued_job_count" == <1-> ]]; then
       return 0
     fi
@@ -214,6 +214,16 @@ stop_idle_listener() {
     print unreachable
     return 0
   }
+  print -r -- "$state"
+}
+
+reconcile_stale_runner_state() {
+  local vm_ip="$1" state="$2"
+  if [[ "$state" == listener ]]; then
+    state=$(stop_idle_listener "$vm_ip")
+    [[ "$state" != draining ]] || /bin/sleep 5
+    state=$(runner_process_state "$vm_ip")
+  fi
   print -r -- "$state"
 }
 
@@ -431,6 +441,7 @@ main() {
     if [[ "$stale_vm" == trips-runner-job-* ]]; then
       if stale_ip=$(/opt/homebrew/bin/tart ip "$stale_vm" 2>/dev/null); then
         stale_state=$(runner_process_state "$stale_ip")
+        stale_state=$(reconcile_stale_runner_state "$stale_ip" "$stale_state")
         if [[ "$stale_state" != absent ]]; then
           log "preserving ${stale_vm}; live state is ${stale_state}"
           preserved_stale=true

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -199,13 +199,14 @@ run_one_ephemeral_runner() {
     for _ in {1..60}; do
       if runner_worker_started "$vm_ip"; then
         runner_claimed=true
-        wait "$runner_pid" >/dev/null 2>&1 || true
-        runner_pid=""
         if wait_for_runner_shutdown "$vm_ip"; then
           runner_status=0
         else
           runner_status=1
         fi
+        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+        runner_pid=""
         break
       fi
       if [[ -n "$runner_pid" ]] && ! /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
@@ -223,13 +224,16 @@ run_one_ephemeral_runner() {
     # not killed without observing its worker.
     if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
       runner_claimed=true
-      [[ -z "$runner_pid" ]] || wait "$runner_pid" >/dev/null 2>&1 || true
-      runner_pid=""
       if wait_for_runner_shutdown "$vm_ip"; then
         runner_status=0
       else
         runner_status=1
       fi
+      if [[ -n "$runner_pid" ]]; then
+        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+      fi
+      runner_pid=""
     fi
     if [[ "$runner_claimed" == false ]]; then
       log "${runner_name} remained idle; removing it"

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -34,47 +34,32 @@ log() {
   print -r -- "$(timestamp) $*"
 }
 
-acquire_controller_lock() {
-  local owner_pid=""
-  if /bin/mkdir "$lock_directory" 2>/dev/null; then
-    printf '%s\n' $$ >"${lock_directory}/owner.pid"
+acquire_lock() {
+  local lock_path="$1" owner_pid="" candidate
+  candidate="${lock_path}.$$"
+  printf '%s\n' $$ >"$candidate"
+  if /bin/ln "$candidate" "$lock_path" 2>/dev/null; then
+    /bin/rm -f "$candidate"
     return 0
   fi
-  [[ -r "${lock_directory}/owner.pid" ]] || return 1
-  read -r owner_pid <"${lock_directory}/owner.pid"
-  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
-    return 1
-  fi
-  /bin/rm -f "${lock_directory}/owner.pid"
-  /bin/rmdir "$lock_directory" 2>/dev/null || return 1
-  /bin/mkdir "$lock_directory" 2>/dev/null || return 1
-  printf '%s\n' $$ >"${lock_directory}/owner.pid"
-}
-
-release_controller_lock() {
-  /bin/rm -f "${lock_directory}/owner.pid"
-  /bin/rmdir "$lock_directory" >/dev/null 2>&1 || true
-}
-
-acquire_lane_lock() {
-  local owner_pid=""
-  if /bin/mkdir "$lane_lock_directory" 2>/dev/null; then
-    printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
-    return 0
-  fi
-  [[ -r "${lane_lock_directory}/owner.pid" ]] || return 1
-  read -r owner_pid <"${lane_lock_directory}/owner.pid"
+  /bin/rm -f "$candidate"
+  [[ -r "$lock_path" ]] || return 1
+  read -r owner_pid <"$lock_path"
   if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then return 1; fi
-  /bin/rm -f "${lane_lock_directory}/owner.pid"
-  /bin/rmdir "$lane_lock_directory" 2>/dev/null || return 1
-  /bin/mkdir "$lane_lock_directory" 2>/dev/null || return 1
-  printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
+  /bin/rm -f "$lock_path"
+  acquire_lock "$lock_path"
 }
 
-release_lane_lock() {
-  /bin/rm -f "${lane_lock_directory}/owner.pid"
-  /bin/rmdir "$lane_lock_directory" >/dev/null 2>&1 || true
+release_lock() {
+  local lock_path="$1" owner_pid=""
+  [[ -r "$lock_path" ]] && read -r owner_pid <"$lock_path"
+  [[ "$owner_pid" != $$ ]] || /bin/rm -f "$lock_path"
 }
+
+acquire_controller_lock() { acquire_lock "$lock_directory"; }
+release_controller_lock() { release_lock "$lock_directory"; }
+acquire_lane_lock() { acquire_lock "$lane_lock_directory"; }
+release_lane_lock() { release_lock "$lane_lock_directory"; }
 
 base64url() {
   /usr/bin/openssl base64 -A | /usr/bin/tr '+/' '-_' | /usr/bin/tr -d '='
@@ -127,10 +112,11 @@ registration_token() {
 }
 
 delete_vm() {
-  local vm_name="$1"
+  local vm_name="$1" vm_list
   /opt/homebrew/bin/tart stop "$vm_name" >/dev/null 2>&1 || true
   /opt/homebrew/bin/tart delete "$vm_name" >/dev/null 2>&1 || true
-  ! /opt/homebrew/bin/tart list --source local --quiet | /usr/bin/grep -qx "$vm_name" || {
+  vm_list=$(/opt/homebrew/bin/tart list --source local --quiet) || return 1
+  ! printf '%s\n' "$vm_list" | /usr/bin/grep -qx "$vm_name" || {
     log "failed to delete ${vm_name}"
     return 1
   }
@@ -392,7 +378,7 @@ main() {
         fi
       fi
       log "removing safely stopped stale ephemeral VM ${stale_vm}"
-      delete_vm "$stale_vm"
+      delete_vm "$stale_vm" || return 1
     fi
   done < <(/opt/homebrew/bin/tart list --source local --quiet)
   [[ "$preserved_stale" == false ]] || return 1

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -61,6 +61,23 @@ shared_lane_has_ephemeral_vm() {
   printf '%s\n' "$vm_list" | /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
 }
 
+clone_artifact_result() {
+  local vm_name="$1" list_status="$2" vm_list="$3"
+  (( list_status == 0 )) || return 3
+  if printf '%s\n' "$vm_list" | /usr/bin/grep -qx "$vm_name"; then
+    log "clone failed after creating ${vm_name}; exiting for startup reconciliation"
+    return 3
+  fi
+  return 1
+}
+
+failed_clone_result() {
+  local vm_name="$1" vm_list list_status
+  vm_list=$(/opt/homebrew/bin/tart list --source local --quiet)
+  list_status=$?
+  clone_artifact_result "$vm_name" "$list_status" "$vm_list"
+}
+
 acquire_clean_lane_lock() {
   acquire_lane_lock || return 1
   if shared_lane_has_ephemeral_vm; then
@@ -297,7 +314,8 @@ run_one_ephemeral_runner() {
   /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || {
     release_lane_lock
     lane_lock_owned=false
-    return 1
+    failed_clone_result "$vm_name"
+    return $?
   }
 
   cleanup_vm() {
@@ -362,7 +380,7 @@ run_one_ephemeral_runner() {
       "admin@${vm_ip}" \
       "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || {
         cleanup_allowed=false
-        return 1
+        return 3
       }
     runner_claimed=false
 
@@ -419,7 +437,8 @@ run_one_ephemeral_runner() {
     lane_priority_requested=false
     if ! cleanup_vm; then
       cleanup_allowed=false
-      runner_status=1
+      log "VM cleanup failed; exiting for startup reconciliation"
+      exit 1
     fi
     if [[ "$cleanup_allowed" == true && -n "$vm_pid" ]]; then
       wait "$vm_pid" >/dev/null 2>&1 || true

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -56,8 +56,9 @@ acquire_priority_lock() { acquire_lock "$native_priority_lock"; }
 release_priority_lock() { release_lock "$native_priority_lock"; }
 
 shared_lane_has_ephemeral_vm() {
-  /opt/homebrew/bin/tart list --source local --quiet |
-    /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
+  local vm_list
+  vm_list=$(/opt/homebrew/bin/tart list --source local --quiet) || return 0
+  printf '%s\n' "$vm_list" | /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
 }
 
 acquire_clean_lane_lock() {
@@ -135,11 +136,18 @@ registration_token() {
 }
 
 repository_has_queued_native_job() {
-  local run_id run_ids="" run_status queued_job_count
+  local page response run_count run_id run_ids="" run_status queued_job_count
   for run_status in queued in_progress; do
-    run_ids+=$(github_api GET "repos/${repository}/actions/runs?status=${run_status}&per_page=20" |
-      /usr/bin/python3 -c 'import json,sys; print("\n".join(str(run["id"]) for run in json.load(sys.stdin)["workflow_runs"]))') || return 1
-    run_ids+=$'\n'
+    page=1
+    while true; do
+      response=$(github_api GET "repos/${repository}/actions/runs?status=${run_status}&per_page=100&page=${page}") || return 1
+      run_ids+=$(printf '%s' "$response" |
+        /usr/bin/python3 -c 'import json,sys; print("\n".join(str(run["id"]) for run in json.load(sys.stdin)["workflow_runs"]))') || return 1
+      run_ids+=$'\n'
+      run_count=$(printf '%s' "$response" | /usr/bin/python3 -c 'import json,sys; print(len(json.load(sys.stdin)["workflow_runs"]))') || return 1
+      (( run_count < 100 )) && break
+      (( page += 1 ))
+    done
   done
 
   while IFS= read -r run_id; do
@@ -151,6 +159,13 @@ repository_has_queued_native_job() {
     fi
   done <<<"$run_ids"
   return 1
+}
+
+installation_api_has_headroom() {
+  local remaining
+  remaining=$(github_api GET rate_limit |
+    /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["resources"]["core"]["remaining"])') || return 1
+  [[ "$remaining" == <1500-> ]]
 }
 
 delete_vm() {
@@ -386,11 +401,12 @@ run_one_ephemeral_runner() {
       wait "$vm_pid" >/dev/null 2>&1 || true
     fi
   }
+  [[ "$cleanup_allowed" == true ]] || runner_status=3
   return "$runner_status"
 }
 
 main() {
-  local stale_ip stale_state preserved_stale=false
+  local runner_result stale_ip stale_state preserved_stale=false
   umask 077
   if ! acquire_controller_lock; then
     log "another iOS runner controller owns ${lock_directory}"
@@ -443,13 +459,23 @@ main() {
     if ! ensure_installation_token; then
       log "GitHub App authentication is unavailable; retrying in 30 seconds"
       /bin/sleep 30
+    elif ! installation_api_has_headroom; then
+      log "GitHub App API has less than 1,500 core requests remaining; pausing discovery for 180 seconds"
+      /bin/sleep 180
     elif repository_has_queued_native_job; then
-      if run_one_ephemeral_runner; then
-        log "ephemeral runner cycle completed"
-      else
-        log "ephemeral runner cycle failed; retrying in 30 seconds"
-        /bin/sleep 30
-      fi
+      run_one_ephemeral_runner
+      runner_result=$?
+      case "$runner_result" in
+        0) log "ephemeral runner cycle completed" ;;
+        3)
+          log "preserved an ambiguous runner; exiting for startup reconciliation"
+          return 1
+          ;;
+        *)
+          log "ephemeral runner cycle failed; retrying in 30 seconds"
+          /bin/sleep 30
+          ;;
+      esac
     else
       /bin/sleep 15
     fi

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -245,6 +245,17 @@ wait_for_runner_shutdown() {
   fi
 }
 
+supervise_claimed_runner() {
+  local vm_ip="$1" state
+  wait_for_runner_shutdown "$vm_ip" && return 0
+  state=$(runner_process_state "$vm_ip")
+  if [[ "$state" != absent ]]; then
+    log "preserving claimed runner after supervision ended; live state is ${state}"
+    cleanup_allowed=false
+  fi
+  return 1
+}
+
 delete_runner_registration() {
   local runner_name="$1" id
   id=$(github_api GET "repos/${repository}/actions/runners?per_page=100" |
@@ -359,7 +370,7 @@ run_one_ephemeral_runner() {
       state=$(runner_process_state "$vm_ip")
       if [[ "$state" == worker ]]; then
         runner_claimed=true
-        if wait_for_runner_shutdown "$vm_ip"; then
+        if supervise_claimed_runner "$vm_ip"; then
           runner_status=0
         else
           runner_status=1
@@ -381,12 +392,12 @@ run_one_ephemeral_runner() {
         /bin/sleep 5
       done
       if [[ "$runner_claimed" == true ]]; then
-        wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+        supervise_claimed_runner "$vm_ip" && runner_status=0 || runner_status=1
       elif (( missing_count >= 6 )); then
         registration_state=$(runner_registration_state "$runner_name")
         if [[ "$registration_state" == busy ]]; then
           runner_claimed=true
-          wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+          supervise_claimed_runner "$vm_ip" && runner_status=0 || runner_status=1
         elif [[ "$registration_state" == idle || "$registration_state" == missing ]]; then
           log "${runner_name} drained without accepting a job; removing it"
           delete_runner_registration "$runner_name" || true
@@ -406,7 +417,10 @@ run_one_ephemeral_runner() {
     trap - INT TERM
     [[ "$lane_priority_requested" != true ]] || release_native_lane_priority
     lane_priority_requested=false
-    cleanup_vm || runner_status=1
+    if ! cleanup_vm; then
+      cleanup_allowed=false
+      runner_status=1
+    fi
     if [[ "$cleanup_allowed" == true && -n "$vm_pid" ]]; then
       wait "$vm_pid" >/dev/null 2>&1 || true
     fi

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -75,6 +75,8 @@ runner_worker_started() {
   /usr/bin/ssh \
     -o BatchMode=yes \
     -o ConnectTimeout=3 \
+    -o ServerAliveInterval=2 \
+    -o ServerAliveCountMax=2 \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
     -i "$ssh_key" \
@@ -181,6 +183,13 @@ run_one_ephemeral_runner() {
       /bin/sleep 5
     done
 
+    # Recheck after the final sleep so a job accepted at the idle deadline is
+    # not killed without observing its worker.
+    if [[ "$runner_claimed" == false ]] && /bin/kill -0 "$runner_pid" >/dev/null 2>&1 && runner_worker_started "$vm_ip"; then
+      runner_claimed=true
+      wait "$runner_pid"
+      runner_status=$?
+    fi
     if [[ "$runner_claimed" == false ]] && /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
       log "${runner_name} remained idle; removing it"
       /bin/kill "$runner_pid" >/dev/null 2>&1 || true

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -17,6 +17,7 @@ readonly log_directory="/Users/jai/Library/Logs/trips-tart-runner"
 readonly work_disk_directory="${TRIPS_TART_WORK_DISK_DIRECTORY:-/Users/jai/.local/share/trips-tart-runner/work-disks}"
 readonly required_volume="${TRIPS_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
+readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
 
 typeset -g github_installation_token=""
 typeset -g github_installation_token_expires_at=0
@@ -39,7 +40,8 @@ acquire_controller_lock() {
     printf '%s\n' $$ >"${lock_directory}/owner.pid"
     return 0
   fi
-  [[ -r "${lock_directory}/owner.pid" ]] && read -r owner_pid <"${lock_directory}/owner.pid"
+  [[ -r "${lock_directory}/owner.pid" ]] || return 1
+  read -r owner_pid <"${lock_directory}/owner.pid"
   if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
     return 1
   fi
@@ -52,6 +54,26 @@ acquire_controller_lock() {
 release_controller_lock() {
   /bin/rm -f "${lock_directory}/owner.pid"
   /bin/rmdir "$lock_directory" >/dev/null 2>&1 || true
+}
+
+acquire_lane_lock() {
+  local owner_pid=""
+  if /bin/mkdir "$lane_lock_directory" 2>/dev/null; then
+    printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
+    return 0
+  fi
+  [[ -r "${lane_lock_directory}/owner.pid" ]] || return 1
+  read -r owner_pid <"${lane_lock_directory}/owner.pid"
+  if [[ "$owner_pid" == <1-> ]] && /bin/kill -0 "$owner_pid" 2>/dev/null; then return 1; fi
+  /bin/rm -f "${lane_lock_directory}/owner.pid"
+  /bin/rmdir "$lane_lock_directory" 2>/dev/null || return 1
+  /bin/mkdir "$lane_lock_directory" 2>/dev/null || return 1
+  printf '%s\n' $$ >"${lane_lock_directory}/owner.pid"
+}
+
+release_lane_lock() {
+  /bin/rm -f "${lane_lock_directory}/owner.pid"
+  /bin/rmdir "$lane_lock_directory" >/dev/null 2>&1 || true
 }
 
 base64url() {
@@ -108,6 +130,10 @@ delete_vm() {
   local vm_name="$1"
   /opt/homebrew/bin/tart stop "$vm_name" >/dev/null 2>&1 || true
   /opt/homebrew/bin/tart delete "$vm_name" >/dev/null 2>&1 || true
+  ! /opt/homebrew/bin/tart list --source local --quiet | /usr/bin/grep -qx "$vm_name" || {
+    log "failed to delete ${vm_name}"
+    return 1
+  }
 }
 
 runner_process_state() {
@@ -174,8 +200,14 @@ delete_runner_registration() {
   github_api DELETE "repos/${repository}/actions/runners/${id}" >/dev/null
 }
 
+runner_registration_state() {
+  local runner_name="$1"
+  github_api GET "repos/${repository}/actions/runners?per_page=100" |
+    RUNNER_NAME="$runner_name" /usr/bin/python3 -c 'import json,os,sys; runner=next((r for r in json.load(sys.stdin)["runners"] if r["name"] == os.environ["RUNNER_NAME"]), None); print("missing" if runner is None else ("busy" if runner["busy"] else "idle"))' || print unreachable
+}
+
 run_one_ephemeral_runner() {
-  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed work_disk ssh_ready linux_runner_count ios_runner_count state missing_count cleanup_allowed
+  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed work_disk ssh_ready state missing_count cleanup_allowed registration_state lane_lock_owned
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
@@ -184,23 +216,20 @@ run_one_ephemeral_runner() {
   vm_pid=""
   runner_status=1
   cleanup_allowed=true
+  lane_lock_owned=false
 
-  while true; do
-    linux_runner_count=$(
-      /opt/homebrew/bin/tart list --source local --quiet |
-        /usr/bin/grep -c '^trips-linux-runner-job-' || true
-    )
-    ios_runner_count=$(
-      /opt/homebrew/bin/tart list --source local --quiet |
-        /usr/bin/grep -c '^trips-runner-job-' || true
-    )
-    (( linux_runner_count == 0 && ios_runner_count == 0 )) && break
+  while ! acquire_lane_lock; do
     log "waiting because another Tart job VM is active"
     /bin/sleep 15
   done
+  lane_lock_owned=true
 
   log "cloning ${base_vm} to ${vm_name}"
-  /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || return 1
+  /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || {
+    release_lane_lock
+    lane_lock_owned=false
+    return 1
+  }
 
   cleanup_vm() {
     if [[ "$cleanup_allowed" != true ]]; then
@@ -208,8 +237,10 @@ run_one_ephemeral_runner() {
       return 0
     fi
     log "deleting ${vm_name}"
-    delete_vm "$vm_name"
+    delete_vm "$vm_name" || return 1
     /bin/rm -f "$work_disk"
+    [[ "$lane_lock_owned" != true ]] || release_lane_lock
+    lane_lock_owned=false
   }
   trap 'cleanup_vm; exit 0' INT TERM
 
@@ -259,7 +290,10 @@ run_one_ephemeral_runner() {
       -o UserKnownHostsFile=/dev/null \
       -i "$ssh_key" \
       "admin@${vm_ip}" \
-      "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || return 1
+      "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; /usr/bin/nohup ./run.sh > runner-controller.log 2>&1 < /dev/null &" || {
+        cleanup_allowed=false
+        return 1
+      }
     runner_claimed=false
 
     for _ in {1..60}; do
@@ -281,7 +315,7 @@ run_one_ephemeral_runner() {
       for _ in {1..24}; do
         state=$(runner_process_state "$vm_ip")
         if [[ "$state" == worker ]]; then runner_claimed=true; break
-        elif [[ "$state" == absent ]]; then (( missing_count += 1 )); (( missing_count >= 3 )) && break
+        elif [[ "$state" == absent ]]; then (( missing_count += 1 )); (( missing_count >= 6 )) && break
         elif [[ "$state" == listener ]]; then stop_idle_listener "$vm_ip" >/dev/null; missing_count=0
         else missing_count=0
         fi
@@ -289,10 +323,20 @@ run_one_ephemeral_runner() {
       done
       if [[ "$runner_claimed" == true ]]; then
         wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
-      elif (( missing_count >= 3 )); then
-        log "${runner_name} drained without accepting a job; removing it"
-        delete_runner_registration "$runner_name" || true
-        runner_status=0
+      elif (( missing_count >= 6 )); then
+        registration_state=$(runner_registration_state "$runner_name")
+        if [[ "$registration_state" == busy ]]; then
+          runner_claimed=true
+          wait_for_runner_shutdown "$vm_ip" && runner_status=0 || runner_status=1
+        elif [[ "$registration_state" == idle || "$registration_state" == missing ]]; then
+          log "${runner_name} drained without accepting a job; removing it"
+          delete_runner_registration "$runner_name" || true
+          runner_status=0
+        else
+          log "could not verify ${runner_name} registration state"
+          cleanup_allowed=false
+          runner_status=1
+        fi
       else
         log "could not prove ${runner_name} idle after draining"
         cleanup_allowed=false
@@ -301,7 +345,7 @@ run_one_ephemeral_runner() {
     fi
   } always {
     trap - INT TERM
-    cleanup_vm
+    cleanup_vm || runner_status=1
     [[ -z "$vm_pid" ]] || wait "$vm_pid" >/dev/null 2>&1 || true
   }
   return "$runner_status"
@@ -335,6 +379,14 @@ main() {
         stale_state=$(runner_process_state "$stale_ip")
         if [[ "$stale_state" != absent ]]; then
           log "preserving ${stale_vm}; live state is ${stale_state}"
+          preserved_stale=true
+          continue
+        fi
+      else
+        stale_state=$(/opt/homebrew/bin/tart list --source local --format json |
+          VM_NAME="$stale_vm" /usr/bin/python3 -c 'import json,os,sys; print(next((vm["State"] for vm in json.load(sys.stdin) if vm["Name"] == os.environ["VM_NAME"]), "unknown"))')
+        if [[ "$stale_state" != stopped ]]; then
+          log "preserving ${stale_vm}; state is ${stale_state} and no IP was available"
           preserved_stale=true
           continue
         fi

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -84,6 +84,37 @@ runner_worker_started() {
     "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null" 2>/dev/null
 }
 
+runner_listener_started() {
+  local vm_ip="$1"
+  /usr/bin/ssh \
+    -o BatchMode=yes \
+    -o ConnectTimeout=3 \
+    -o ServerAliveInterval=2 \
+    -o ServerAliveCountMax=2 \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "$ssh_key" \
+    "admin@${vm_ip}" \
+    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Listener run' >/dev/null" 2>/dev/null
+}
+
+wait_for_runner_shutdown() {
+  local vm_ip="$1" missing_count=0 deadline
+  deadline=$(( $(/bin/date +%s) + 3300 ))
+  while (( missing_count < 3 && $(/bin/date +%s) < deadline )); do
+    if runner_worker_started "$vm_ip" || runner_listener_started "$vm_ip"; then
+      missing_count=0
+    else
+      (( missing_count += 1 ))
+    fi
+    (( missing_count >= 3 )) || /bin/sleep 5
+  done
+  if (( missing_count < 3 )); then
+    log "runner processes exceeded the 55-minute execution budget"
+    return 1
+  fi
+}
+
 run_one_ephemeral_runner() {
   local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_pid runner_claimed work_disk ssh_ready linux_runner_count
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
@@ -166,34 +197,46 @@ run_one_ephemeral_runner() {
     runner_claimed=false
 
     for _ in {1..60}; do
-      if ! /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
-        wait "$runner_pid"
-        runner_status=$?
-        break
-      fi
-
-      # GitHub's runner metadata can report a stale busy state. Only the
-      # workload process proves that this ephemeral runner accepted a job.
       if runner_worker_started "$vm_ip"; then
         runner_claimed=true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+        runner_pid=""
+        if wait_for_runner_shutdown "$vm_ip"; then
+          runner_status=0
+        else
+          runner_status=1
+        fi
+        break
+      fi
+      if [[ -n "$runner_pid" ]] && ! /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
         wait "$runner_pid"
         runner_status=$?
-        break
+        runner_pid=""
+        if ! runner_listener_started "$vm_ip"; then
+          break
+        fi
       fi
       /bin/sleep 5
     done
 
     # Recheck after the final sleep so a job accepted at the idle deadline is
     # not killed without observing its worker.
-    if [[ "$runner_claimed" == false ]] && /bin/kill -0 "$runner_pid" >/dev/null 2>&1 && runner_worker_started "$vm_ip"; then
+    if [[ "$runner_claimed" == false ]] && runner_worker_started "$vm_ip"; then
       runner_claimed=true
-      wait "$runner_pid"
-      runner_status=$?
+      [[ -z "$runner_pid" ]] || wait "$runner_pid" >/dev/null 2>&1 || true
+      runner_pid=""
+      if wait_for_runner_shutdown "$vm_ip"; then
+        runner_status=0
+      else
+        runner_status=1
+      fi
     fi
-    if [[ "$runner_claimed" == false ]] && /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
+    if [[ "$runner_claimed" == false ]]; then
       log "${runner_name} remained idle; removing it"
-      /bin/kill "$runner_pid" >/dev/null 2>&1 || true
-      wait "$runner_pid" >/dev/null 2>&1 || true
+      if [[ -n "$runner_pid" ]]; then
+        /bin/kill "$runner_pid" >/dev/null 2>&1 || true
+        wait "$runner_pid" >/dev/null 2>&1 || true
+      fi
       runner_pid=""
       runner_status=0
     fi

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -18,6 +18,7 @@ readonly work_disk_directory="${TRIPS_TART_WORK_DISK_DIRECTORY:-/Users/jai/.loca
 readonly required_volume="${TRIPS_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
 readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
+readonly native_priority_file="${TRIPS_TART_NATIVE_PRIORITY_FILE:-/Users/jai/Library/Logs/trips-tart-runner-native-priority}"
 
 typeset -g github_installation_token=""
 typeset -g github_installation_token_expires_at=0
@@ -60,6 +61,18 @@ acquire_controller_lock() { acquire_lock "$lock_directory"; }
 release_controller_lock() { release_lock "$lock_directory"; }
 acquire_lane_lock() { acquire_lock "$lane_lock_directory"; }
 release_lane_lock() { release_lock "$lane_lock_directory"; }
+
+request_native_lane_priority() {
+  local candidate="${native_priority_file}.$$"
+  printf '%s\n' $$ >"$candidate"
+  /bin/mv -f "$candidate" "$native_priority_file"
+}
+
+release_native_lane_priority() {
+  local owner_pid=""
+  [[ -r "$native_priority_file" ]] && read -r owner_pid <"$native_priority_file"
+  [[ "$owner_pid" != $$ ]] || /bin/rm -f "$native_priority_file"
+}
 
 base64url() {
   /usr/bin/openssl base64 -A | /usr/bin/tr '+/' '-_' | /usr/bin/tr -d '='
@@ -109,6 +122,25 @@ registration_token() {
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "https://api.github.com/repos/${repository}/actions/runners/registration-token" |
     /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+}
+
+repository_has_queued_native_job() {
+  local run_id run_ids="" run_status queued_job_count
+  for run_status in queued in_progress; do
+    run_ids+=$(github_api GET "repos/${repository}/actions/runs?status=${run_status}&per_page=20" |
+      /usr/bin/python3 -c 'import json,sys; print("\n".join(str(run["id"]) for run in json.load(sys.stdin)["workflow_runs"]))') || return 1
+    run_ids+=$'\n'
+  done
+
+  while IFS= read -r run_id; do
+    [[ -n "$run_id" ]] || continue
+    queued_job_count=$(github_api GET "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
+      /usr/bin/python3 -c 'import json,sys; required={"self-hosted","macOS","ARM64","tart","ios"}; print(sum(job["status"] == "queued" and required.issubset(job["labels"]) for job in json.load(sys.stdin)["jobs"]))') || continue
+    if [[ "$queued_job_count" == <1-> ]]; then
+      return 0
+    fi
+  done <<<"$run_ids"
+  return 1
 }
 
 delete_vm() {
@@ -193,7 +225,7 @@ runner_registration_state() {
 }
 
 run_one_ephemeral_runner() {
-  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed work_disk ssh_ready state missing_count cleanup_allowed registration_state lane_lock_owned
+  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_claimed work_disk ssh_ready state missing_count cleanup_allowed registration_state lane_lock_owned lane_priority_requested
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
@@ -203,12 +235,17 @@ run_one_ephemeral_runner() {
   runner_status=1
   cleanup_allowed=true
   lane_lock_owned=false
+  lane_priority_requested=false
 
+  request_native_lane_priority
+  lane_priority_requested=true
   while ! acquire_lane_lock; do
     log "waiting because another Tart job VM is active"
     /bin/sleep 15
   done
   lane_lock_owned=true
+  release_native_lane_priority
+  lane_priority_requested=false
 
   log "cloning ${base_vm} to ${vm_name}"
   /opt/homebrew/bin/tart clone "$base_vm" "$vm_name" || {
@@ -331,6 +368,8 @@ run_one_ephemeral_runner() {
     fi
   } always {
     trap - INT TERM
+    [[ "$lane_priority_requested" != true ]] || release_native_lane_priority
+    lane_priority_requested=false
     cleanup_vm || runner_status=1
     [[ -z "$vm_pid" ]] || wait "$vm_pid" >/dev/null 2>&1 || true
   }
@@ -388,13 +427,19 @@ main() {
   done
 
   while true; do
-    if run_one_ephemeral_runner; then
-      log "ephemeral runner cycle completed"
+    if repository_has_queued_native_job; then
+      if run_one_ephemeral_runner; then
+        log "ephemeral runner cycle completed"
+      else
+        log "ephemeral runner cycle failed; retrying in 30 seconds"
+        /bin/sleep 30
+      fi
     else
-      log "ephemeral runner cycle failed; retrying in 30 seconds"
-      /bin/sleep 30
+      /bin/sleep 15
     fi
   done
 }
 
-main
+if [[ "${TRIPS_RUNNER_CONTROLLER_TEST_MODE:-false}" != true ]]; then
+  main
+fi

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -142,6 +142,14 @@ github_api() {
     "https://api.github.com/${endpoint}"
 }
 
+github_user_api() {
+  local endpoint="$1"
+  /opt/homebrew/bin/gh api \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "$endpoint"
+}
+
 registration_token() {
   local installation_token="$1"
   /usr/bin/curl -fsS -X POST \
@@ -157,7 +165,7 @@ repository_has_queued_native_job() {
   for run_status in queued in_progress; do
     page=1
     while true; do
-      response=$(github_api GET "repos/${repository}/actions/runs?status=${run_status}&per_page=100&page=${page}") || return 1
+      response=$(github_user_api "repos/${repository}/actions/runs?status=${run_status}&per_page=100&page=${page}") || return 1
       run_ids+=$(printf '%s' "$response" |
         /usr/bin/python3 -c 'import json,sys; print("\n".join(str(run["id"]) for run in json.load(sys.stdin)["workflow_runs"]))') || return 1
       run_ids+=$'\n'
@@ -169,7 +177,7 @@ repository_has_queued_native_job() {
 
   while IFS= read -r run_id; do
     [[ -n "$run_id" ]] || continue
-    queued_job_count=$(github_api GET "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
+    queued_job_count=$(github_user_api "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
       AVAILABLE_LABELS="self-hosted,macOS,ARM64,${runner_labels}" /usr/bin/python3 -c 'import json,os,sys; available=set(os.environ["AVAILABLE_LABELS"].split(",")); print(sum(job["status"] == "queued" and set(job["labels"]).issubset(available) for job in json.load(sys.stdin)["jobs"]))') || continue
     if [[ "$queued_job_count" == <1-> ]]; then
       return 0
@@ -178,9 +186,9 @@ repository_has_queued_native_job() {
   return 1
 }
 
-installation_api_has_headroom() {
+user_api_has_headroom() {
   local remaining
-  remaining=$(github_api GET rate_limit |
+  remaining=$(github_user_api rate_limit |
     /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["resources"]["core"]["remaining"])') || return 1
   [[ "$remaining" == <1500-> ]]
 }
@@ -469,6 +477,10 @@ main() {
     log "base VM ${base_vm} is missing"
     return 1
   fi
+  if ! /opt/homebrew/bin/gh auth token >/dev/null 2>&1; then
+    log "GitHub CLI authentication is unavailable for private-repository queue discovery"
+    return 1
+  fi
 
   while IFS= read -r stale_vm; do
     if [[ "$stale_vm" == trips-runner-job-* ]]; then
@@ -503,8 +515,8 @@ main() {
     if ! ensure_installation_token; then
       log "GitHub App authentication is unavailable; retrying in 30 seconds"
       /bin/sleep 30
-    elif ! installation_api_has_headroom; then
-      log "GitHub App API has less than 1,500 core requests remaining; pausing discovery for 180 seconds"
+    elif ! user_api_has_headroom; then
+      log "GitHub user API has less than 1,500 core requests remaining; pausing discovery for 180 seconds"
       /bin/sleep 180
     elif repository_has_queued_native_job; then
       run_one_ephemeral_runner

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -19,13 +19,16 @@ readonly required_volume="${TRIPS_TART_REQUIRED_VOLUME:-}"
 readonly lock_directory="${log_directory}/controller.lock"
 readonly lane_lock_directory="/Users/jai/Library/Logs/trips-tart-runner-lane.lock"
 readonly native_priority_file="${TRIPS_TART_NATIVE_PRIORITY_FILE:-/Users/jai/Library/Logs/trips-tart-runner-native-priority}"
+readonly native_priority_lock="${native_priority_file}.lock"
 
 typeset -g github_installation_token=""
 typeset -g github_installation_token_expires_at=0
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
-mkdir -p "$log_directory"
+if [[ "${TRIPS_RUNNER_CONTROLLER_TEST_MODE:-false}" != true ]]; then
+  mkdir -p "$log_directory"
+fi
 
 timestamp() {
   /bin/date -u '+%Y-%m-%dT%H:%M:%SZ'
@@ -49,17 +52,36 @@ acquire_controller_lock() { acquire_lock "$lock_directory"; }
 release_controller_lock() { release_lock "$lock_directory"; }
 acquire_lane_lock() { acquire_lock "$lane_lock_directory"; }
 release_lane_lock() { release_lock "$lane_lock_directory"; }
+acquire_priority_lock() { acquire_lock "$native_priority_lock"; }
+release_priority_lock() { release_lock "$native_priority_lock"; }
+
+shared_lane_has_ephemeral_vm() {
+  /opt/homebrew/bin/tart list --source local --quiet |
+    /usr/bin/grep -Eq '^trips-(linux-)?runner-job-'
+}
+
+acquire_clean_lane_lock() {
+  acquire_lane_lock || return 1
+  if shared_lane_has_ephemeral_vm; then
+    release_lane_lock
+    return 1
+  fi
+}
 
 request_native_lane_priority() {
   local candidate="${native_priority_file}.$$"
+  while ! acquire_priority_lock; do /bin/sleep 1; done
   printf '%s\n' $$ >"$candidate"
   /bin/mv -f "$candidate" "$native_priority_file"
+  release_priority_lock
 }
 
 release_native_lane_priority() {
   local owner_pid=""
+  while ! acquire_priority_lock; do /bin/sleep 1; done
   [[ -r "$native_priority_file" ]] && read -r owner_pid <"$native_priority_file"
   [[ "$owner_pid" != $$ ]] || /bin/rm -f "$native_priority_file"
+  release_priority_lock
 }
 
 base64url() {
@@ -103,9 +125,9 @@ github_api() {
 }
 
 registration_token() {
-  ensure_installation_token || return 1
+  local installation_token="$1"
   /usr/bin/curl -fsS -X POST \
-    -H "Authorization: Bearer $github_installation_token" \
+    -H "Authorization: Bearer $installation_token" \
     -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "https://api.github.com/repos/${repository}/actions/runners/registration-token" |
@@ -227,7 +249,7 @@ run_one_ephemeral_runner() {
 
   request_native_lane_priority
   lane_priority_requested=true
-  while ! acquire_lane_lock; do
+  while ! acquire_clean_lane_lock; do
     log "waiting because another Tart job VM is active"
     /bin/sleep 15
   done
@@ -290,7 +312,8 @@ run_one_ephemeral_runner() {
       "admin@${vm_ip}" \
       'set -e; root_store=$(diskutil info / | awk -F: '\''/APFS Physical Store/{gsub(/ /, "", $2); print $2; exit}'\''); root_device=$(printf "%s" "$root_store" | sed -E "s/s[0-9]+$//"); work_device=$(diskutil list physical | awk '\''/^\/dev\/disk[0-9]+ /{gsub("/dev/", "", $1); print $1}'\'' | grep -v "^${root_device}$"); test "$(printf "%s\n" "$work_device" | wc -l | tr -d " ")" = 1; printf "%s\n" "$root_device" "$work_device" | while IFS= read -r device; do printf "%s\n" "$device" | grep -Eq "^disk[0-9]+$" || exit 1; done; sudo diskutil eraseDisk APFS RunnerWork GPT "/dev/$work_device" >/dev/null; mkdir -p /Volumes/RunnerWork/_work /Volumes/RunnerWork/DerivedData /Volumes/RunnerWork/Archives /Volumes/RunnerWork/tmp /Volumes/RunnerWork/npm-cache /Volumes/RunnerWork/user-cache /Volumes/RunnerWork/core-simulator-cache /Volumes/RunnerWork/core-simulator-devices /Volumes/RunnerWork/expo /Volumes/RunnerWork/gradle /Volumes/RunnerWork/cocoapods /Volumes/RunnerWork/runner-diag /Users/admin/Library/Developer/Xcode /Users/admin/Library/Developer/CoreSimulator; sudo rm -rf /Library/Developer/CoreSimulator/Caches; sudo ln -s /Volumes/RunnerWork/core-simulator-cache /Library/Developer/CoreSimulator/Caches; xcrun simctl runtime scan-and-mount >/dev/null; runtime_ready=false; for _ in {1..45}; do if xcrun simctl list runtimes | grep -q "iOS"; then runtime_ready=true; break; fi; sleep 2; done; [ "$runtime_ready" = true ]; launchctl kill SIGKILL "gui/$(id -u)/com.apple.CoreSimulator.CoreSimulatorService" >/dev/null 2>&1 || true; sleep 2; sudo rm -rf /Users/admin/Library/Developer/Xcode/DerivedData /Users/admin/Library/Developer/Xcode/Archives /Users/admin/Library/Developer/CoreSimulator/Devices /Users/admin/Library/Caches /Users/admin/.expo /Users/admin/.gradle /Users/admin/.cocoapods /Users/admin/actions-runner/_diag; ln -s /Volumes/RunnerWork/DerivedData /Users/admin/Library/Developer/Xcode/DerivedData; ln -s /Volumes/RunnerWork/Archives /Users/admin/Library/Developer/Xcode/Archives; ln -s /Volumes/RunnerWork/core-simulator-devices /Users/admin/Library/Developer/CoreSimulator/Devices; ln -s /Volumes/RunnerWork/user-cache /Users/admin/Library/Caches; ln -s /Volumes/RunnerWork/expo /Users/admin/.expo; ln -s /Volumes/RunnerWork/gradle /Users/admin/.gradle; ln -s /Volumes/RunnerWork/cocoapods /Users/admin/.cocoapods; ln -s /Volumes/RunnerWork/runner-diag /Users/admin/actions-runner/_diag' || return 1
 
-    token=$(registration_token) || return 1
+    ensure_installation_token || return 1
+    token=$(registration_token "$github_installation_token") || return 1
     log "registering ${runner_name}"
     printf '%s\n' "$token" | /usr/bin/ssh \
       -o BatchMode=yes \
@@ -359,7 +382,9 @@ run_one_ephemeral_runner() {
     [[ "$lane_priority_requested" != true ]] || release_native_lane_priority
     lane_priority_requested=false
     cleanup_vm || runner_status=1
-    [[ -z "$vm_pid" ]] || wait "$vm_pid" >/dev/null 2>&1 || true
+    if [[ "$cleanup_allowed" == true && -n "$vm_pid" ]]; then
+      wait "$vm_pid" >/dev/null 2>&1 || true
+    fi
   }
   return "$runner_status"
 }

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -70,14 +70,27 @@ delete_vm() {
   /opt/homebrew/bin/tart delete "$vm_name" >/dev/null 2>&1 || true
 }
 
+runner_worker_started() {
+  local vm_ip="$1"
+  /usr/bin/ssh \
+    -o BatchMode=yes \
+    -o ConnectTimeout=3 \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "$ssh_key" \
+    "admin@${vm_ip}" \
+    "/usr/bin/pgrep -f '^${runner_root}/bin/Runner.Worker ' >/dev/null" 2>/dev/null
+}
+
 run_one_ephemeral_runner() {
-  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status work_disk ssh_ready linux_runner_count
+  local suffix vm_name vm_log vm_pid vm_ip token runner_name runner_status runner_pid runner_claimed work_disk ssh_ready linux_runner_count
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-runner-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
   vm_log="${log_directory}/${vm_name}.log"
   work_disk="${work_disk_directory}/${vm_name}.raw"
   vm_pid=""
+  runner_pid=""
   runner_status=1
 
   while true; do
@@ -146,8 +159,35 @@ run_one_ephemeral_runner() {
       -o UserKnownHostsFile=/dev/null \
       -i "$ssh_key" \
       "admin@${vm_ip}" \
-      "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; ./run.sh"
-    runner_status=$?
+      "IFS= read -r registration_token; export PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/Volumes/RunnerWork/tmp npm_config_cache=/Volumes/RunnerWork/npm-cache; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work /Volumes/RunnerWork/_work; exec ./run.sh" &
+    runner_pid=$!
+    runner_claimed=false
+
+    for _ in {1..60}; do
+      if ! /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
+        wait "$runner_pid"
+        runner_status=$?
+        break
+      fi
+
+      # GitHub's runner metadata can report a stale busy state. Only the
+      # workload process proves that this ephemeral runner accepted a job.
+      if runner_worker_started "$vm_ip"; then
+        runner_claimed=true
+        wait "$runner_pid"
+        runner_status=$?
+        break
+      fi
+      /bin/sleep 5
+    done
+
+    if [[ "$runner_claimed" == false ]] && /bin/kill -0 "$runner_pid" >/dev/null 2>&1; then
+      log "${runner_name} remained idle; removing it"
+      /bin/kill "$runner_pid" >/dev/null 2>&1 || true
+      wait "$runner_pid" >/dev/null 2>&1 || true
+      runner_pid=""
+      runner_status=0
+    fi
   } always {
     trap - INT TERM
     cleanup_vm

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -27,6 +27,13 @@ actionlint "${actionlint_args[@]}" "$repo_root"/.github/workflows/*.yaml
 actionlint "${actionlint_args[@]}" "$tmp_dir/.github/workflows"/*.yaml
 actionlint "${actionlint_args[@]}" "$repo_root"/templates/*.yaml
 shellcheck "$repo_root/scripts/generate-caller-workflows.sh" "$repo_root/scripts/validate-workflows.sh"
+zsh -n \
+  "$repo_root/scripts/start-trips-linux-tart-runner.command" \
+  "$repo_root/scripts/start-trips-tart-runner.command" \
+  "$repo_root/scripts/trips-linux-tart-runner-controller.zsh" \
+  "$repo_root/scripts/trips-tart-runner-controller.zsh" \
+  "$repo_root/tests/runner-controller-priority-test.zsh"
+"$repo_root/tests/runner-controller-priority-test.zsh"
 
 if rg -n 'Claude PR Assistant|@claude|CLAUDE_' \
   "$repo_root/.github/workflows" \

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -11,6 +11,8 @@ TRIPS_TART_LANE_POLL_SECONDS=0 \
   /bin/zsh -c '
     set -euo pipefail
     source "$1/scripts/trips-linux-tart-runner-controller.zsh"
+    acquire_priority_lock() { return 0; }
+    release_priority_lock() { return 0; }
     printf "%s\n" $$ >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
     native_lane_priority_requested
     printf "%s\n" 999999 >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
@@ -26,10 +28,17 @@ TRIPS_TART_LANE_POLL_SECONDS=0 \
       printf "%s\n" $$ >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
       return 0
     }
+    shared_lane_has_ephemeral_vm() { return 1; }
     typeset -g lane_released=false
     release_lane_lock() { lane_released=true; }
     acquire_linux_lane && exit 1
     [[ $? == 2 ]]
+    [[ "$lane_released" == true ]]
+
+    acquire_lane_lock() { return 0; }
+    shared_lane_has_ephemeral_vm() { return 0; }
+    lane_released=false
+    ! acquire_clean_lane_lock
     [[ "$lane_released" == true ]]
   ' _ "$repository_root"
 
@@ -38,6 +47,8 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
   /bin/zsh -c '
     set -euo pipefail
     source "$1/scripts/trips-tart-runner-controller.zsh"
+    acquire_priority_lock() { return 0; }
+    release_priority_lock() { return 0; }
     request_native_lane_priority
     [[ "$(<"$TRIPS_TART_NATIVE_PRIORITY_FILE")" == $$ ]]
     release_native_lane_priority
@@ -66,6 +77,14 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
       fi
     }
     ! repository_has_queued_native_job
+
+    typeset -g github_installation_token="expired"
+    ensure_installation_token() { github_installation_token="fresh"; }
+    registration_token() { [[ "$1" == fresh ]] && print runner-token; }
+    ensure_installation_token
+    token=$(registration_token "$github_installation_token")
+    [[ "$github_installation_token" == fresh ]]
+    [[ "$token" == runner-token ]]
   ' _ "$repository_root"
 
 print "runner controller native-priority tests passed"

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -1,0 +1,55 @@
+#!/bin/zsh
+set -euo pipefail
+
+readonly repository_root="${0:A:h:h}"
+readonly scratch_directory="$(mktemp -d "${repository_root}/tmp.runner-priority.XXXXXX")"
+trap '/bin/rm -rf "$scratch_directory"' EXIT
+
+TRIPS_RUNNER_CONTROLLER_TEST_MODE=true \
+TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
+  /bin/zsh -c '
+    set -euo pipefail
+    source "$1/scripts/trips-linux-tart-runner-controller.zsh"
+    printf "%s\n" $$ >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
+    native_lane_priority_requested
+    printf "%s\n" 999999 >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
+    ! native_lane_priority_requested
+    [[ ! -e "$TRIPS_TART_NATIVE_PRIORITY_FILE" ]]
+  ' _ "$repository_root"
+
+TRIPS_RUNNER_CONTROLLER_TEST_MODE=true \
+TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
+  /bin/zsh -c '
+    set -euo pipefail
+    source "$1/scripts/trips-tart-runner-controller.zsh"
+    request_native_lane_priority
+    [[ "$(<"$TRIPS_TART_NATIVE_PRIORITY_FILE")" == $$ ]]
+    release_native_lane_priority
+    [[ ! -e "$TRIPS_TART_NATIVE_PRIORITY_FILE" ]]
+
+    github_api() {
+      local method="$1" endpoint="$2"
+      if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
+        print "{\"workflow_runs\":[]}" 
+      elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
+        print "{\"workflow_runs\":[{\"id\":42}]}"
+      else
+        print "{\"jobs\":[{\"status\":\"queued\",\"labels\":[\"self-hosted\",\"macOS\",\"ARM64\",\"tart\",\"ios\"]}]}"
+      fi
+    }
+    repository_has_queued_native_job
+
+    github_api() {
+      local method="$1" endpoint="$2"
+      if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
+        print "{\"workflow_runs\":[{\"id\":43}]}"
+      elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
+        print "{\"workflow_runs\":[]}" 
+      else
+        print "{\"jobs\":[{\"status\":\"queued\",\"labels\":[\"self-hosted\",\"linux\",\"arm64\",\"jai-ci\"]}]}"
+      fi
+    }
+    ! repository_has_queued_native_job
+  ' _ "$repository_root"
+
+print "runner controller native-priority tests passed"

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -7,6 +7,7 @@ trap '/bin/rm -rf "$scratch_directory"' EXIT
 
 TRIPS_RUNNER_CONTROLLER_TEST_MODE=true \
 TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
+TRIPS_TART_LANE_POLL_SECONDS=0 \
   /bin/zsh -c '
     set -euo pipefail
     source "$1/scripts/trips-linux-tart-runner-controller.zsh"
@@ -15,6 +16,21 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     printf "%s\n" 999999 >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
     ! native_lane_priority_requested
     [[ ! -e "$TRIPS_TART_NATIVE_PRIORITY_FILE" ]]
+
+    typeset -g lane_acquire_calls=0
+    acquire_lane_lock() {
+      (( lane_acquire_calls += 1 ))
+      if (( lane_acquire_calls == 1 )); then
+        return 1
+      fi
+      printf "%s\n" $$ >"$TRIPS_TART_NATIVE_PRIORITY_FILE"
+      return 0
+    }
+    typeset -g lane_released=false
+    release_lane_lock() { lane_released=true; }
+    acquire_linux_lane && exit 1
+    [[ $? == 2 ]]
+    [[ "$lane_released" == true ]]
   ' _ "$repository_root"
 
 TRIPS_RUNNER_CONTROLLER_TEST_MODE=true \
@@ -30,7 +46,7 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     github_api() {
       local method="$1" endpoint="$2"
       if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
-        print "{\"workflow_runs\":[]}" 
+        print "{\"workflow_runs\":[]}"
       elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
         print "{\"workflow_runs\":[{\"id\":42}]}"
       else
@@ -44,7 +60,7 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
       if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
         print "{\"workflow_runs\":[{\"id\":43}]}"
       elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
-        print "{\"workflow_runs\":[]}" 
+        print "{\"workflow_runs\":[]}"
       else
         print "{\"jobs\":[{\"status\":\"queued\",\"labels\":[\"self-hosted\",\"linux\",\"arm64\",\"jai-ci\"]}]}"
       fi

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -35,6 +35,12 @@ TRIPS_TART_LANE_POLL_SECONDS=0 \
     [[ $? == 2 ]]
     [[ "$lane_released" == true ]]
 
+    wait_for_runner_shutdown() { return 1; }
+    runner_process_state() { print worker; }
+    typeset -g cleanup_allowed=true
+    ! supervise_claimed_runner 192.0.2.1
+    [[ "$cleanup_allowed" == false ]]
+
     acquire_lane_lock() { return 0; }
     shared_lane_has_ephemeral_vm() { return 0; }
     lane_released=false
@@ -59,6 +65,12 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     sleep() { return 0; }
     [[ "$(reconcile_stale_runner_state 192.0.2.1 listener)" == absent ]]
     [[ "$(reconcile_stale_runner_state 192.0.2.1 worker)" == worker ]]
+
+    wait_for_runner_shutdown() { return 1; }
+    runner_process_state() { print worker; }
+    typeset -g cleanup_allowed=true
+    ! supervise_claimed_runner 192.0.2.1
+    [[ "$cleanup_allowed" == false ]]
 
     github_api() {
       local method="$1" endpoint="$2"

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -92,8 +92,8 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     [[ $result == 3 ]]
     set -e
 
-    github_api() {
-      local method="$1" endpoint="$2"
+    github_user_api() {
+      local endpoint="$1"
       if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
         print "{\"workflow_runs\":[]}"
       elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
@@ -104,8 +104,8 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     }
     repository_has_queued_native_job
 
-    github_api() {
-      local method="$1" endpoint="$2"
+    github_user_api() {
+      local endpoint="$1"
       if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
         print "{\"workflow_runs\":[{\"id\":44}]}"
       elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
@@ -116,8 +116,8 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     }
     ! repository_has_queued_native_job
 
-    github_api() {
-      local method="$1" endpoint="$2"
+    github_user_api() {
+      local endpoint="$1"
       if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
         print "{\"workflow_runs\":[{\"id\":43}]}"
       elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -41,6 +41,16 @@ TRIPS_TART_LANE_POLL_SECONDS=0 \
     ! supervise_claimed_runner 192.0.2.1
     [[ "$cleanup_allowed" == false ]]
 
+    vm_list=$(printf "base\ntrips-linux-runner-job-test\n")
+    set +e
+    clone_artifact_result trips-linux-runner-job-test 0 "$vm_list"; result=$?
+    [[ $result == 3 ]]
+    clone_artifact_result trips-linux-runner-job-other 0 "$vm_list"; result=$?
+    [[ $result == 1 ]]
+    clone_artifact_result trips-linux-runner-job-test 1 ""; result=$?
+    [[ $result == 3 ]]
+    set -e
+
     acquire_lane_lock() { return 0; }
     shared_lane_has_ephemeral_vm() { return 0; }
     lane_released=false
@@ -71,6 +81,16 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     typeset -g cleanup_allowed=true
     ! supervise_claimed_runner 192.0.2.1
     [[ "$cleanup_allowed" == false ]]
+
+    vm_list=$(printf "base\ntrips-runner-job-test\n")
+    set +e
+    clone_artifact_result trips-runner-job-test 0 "$vm_list"; result=$?
+    [[ $result == 3 ]]
+    clone_artifact_result trips-runner-job-other 0 "$vm_list"; result=$?
+    [[ $result == 1 ]]
+    clone_artifact_result trips-runner-job-test 1 ""; result=$?
+    [[ $result == 3 ]]
+    set -e
 
     github_api() {
       local method="$1" endpoint="$2"

--- a/tests/runner-controller-priority-test.zsh
+++ b/tests/runner-controller-priority-test.zsh
@@ -54,6 +54,12 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
     release_native_lane_priority
     [[ ! -e "$TRIPS_TART_NATIVE_PRIORITY_FILE" ]]
 
+    stop_idle_listener() { print draining; }
+    runner_process_state() { print absent; }
+    sleep() { return 0; }
+    [[ "$(reconcile_stale_runner_state 192.0.2.1 listener)" == absent ]]
+    [[ "$(reconcile_stale_runner_state 192.0.2.1 worker)" == worker ]]
+
     github_api() {
       local method="$1" endpoint="$2"
       if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
@@ -65,6 +71,18 @@ TRIPS_TART_NATIVE_PRIORITY_FILE="${scratch_directory}/native-priority" \
       fi
     }
     repository_has_queued_native_job
+
+    github_api() {
+      local method="$1" endpoint="$2"
+      if [[ "$endpoint" == *"actions/runs?status=queued"* ]]; then
+        print "{\"workflow_runs\":[{\"id\":44}]}"
+      elif [[ "$endpoint" == *"actions/runs?status=in_progress"* ]]; then
+        print "{\"workflow_runs\":[]}"
+      else
+        print "{\"jobs\":[{\"status\":\"queued\",\"labels\":[\"self-hosted\",\"macOS\",\"ARM64\",\"tart\",\"ios\",\"other-host\"]}]}"
+      fi
+    }
+    ! repository_has_queued_native_job
 
     github_api() {
       local method="$1" endpoint="$2"


### PR DESCRIPTION
## Summary
- require a live Runner.Worker process before Linux or iOS is treated as executing a job
- recycle unclaimed listeners, preserve ambiguous or still-running workers, and restart safely after cleanup faults
- serialize Linux/iOS Tart VM ownership with native priority and exact claimable-label discovery
- bound GitHub API polling, paginate active-run discovery, and fail closed when state cannot be proven

## Related Issue
- jai/trips#140 (Move a segment to an existing or new trip): native delivery was starved by stale runner state while frontend PR #639 awaited exact-head evidence.

## Validation
- zsh syntax for both controllers, launchers, and deterministic tests
- tests/runner-controller-priority-test.zsh
- scripts/validate-workflows.sh
- git diff --check
- independent exact-head gpt-5.6-sol xhigh review with Fast Mode disabled

## Rollout
The pushed controller repair is not installed yet because exact-head iOS Maestro job 97027326647 currently owns the shared native Tart lane. Install only after that VM and seeded-state cleanup complete; then allow the serialized PR checks to exercise the new Linux controller.