### PR TITLE
fix(ci): provide writable shared tool directory

### DIFF
--- a/.github/workflows/coverage-octocov.yml
+++ b/.github/workflows/coverage-octocov.yml
@@ -121,6 +121,12 @@ jobs:
               - 🎯 If `main` is **>= ${{ inputs.coverage_floor }}%**: PR coverage must be **>= ${{ inputs.coverage_floor }}%**
           YAML
 
+      - name: Add writable tool directory
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
       - name: Run octocov (coverage reporting/enforcement)
         uses: k1LoW/octocov-action@v1
         env:


### PR DESCRIPTION
## Summary

- add a runner-temp binary directory to `GITHUB_PATH` before octocov installs its CLI
- keep shared coverage enforcement working on non-root ephemeral Linux runners
- preserve the existing least-privilege runner boundary and ratchet policy

## Evidence

- `scripts/validate-workflows.sh`
- reproduced in `jai/trips-frontend#639` job `97208102903`: `could not find a writable bin path`
- exact-diff independent review required before merge

Closes #124
