### PR TITLE
fix(ci): rotate Linux runner repositories fairly

### DIFF
--- a/.github/workflows/code-review-full.yaml
+++ b/.github/workflows/code-review-full.yaml
@@ -263,6 +263,12 @@ jobs:
               - missing product/owner decision required to proceed
             - When hard-blocked, post one explicit BLOCKED: summary comment with the exact blocker and exact next action.
 
+            ## Runner Liveness (MANDATORY)
+            - This review job owns the repository's only Linux runner while it executes. Other Linux checks cannot start until you exit.
+            - Never run `gh pr checks --watch`, `gh run watch`, a polling loop, or any command that waits for sibling workflows or jobs.
+            - You may inspect check state once for diagnostic context. Pending sibling checks are not a review blocker and must not delay your decision.
+            - Review and verify the exact diff with commands that can complete inside this job, emit the structured decision marker, and exit promptly so queued checks can run.
+
             Use inline comments ONLY for issues that need to be fixed or changed.
             Do NOT leave inline comments for praise or positive observations.
             Post a final summary comment using 'gh pr comment'.

--- a/.github/workflows/code-review-full.yaml
+++ b/.github/workflows/code-review-full.yaml
@@ -265,7 +265,7 @@ jobs:
 
             ## Runner Liveness (MANDATORY)
             - This review job owns the repository's only Linux runner while it executes. Other Linux checks cannot start until you exit.
-            - Never run `gh pr checks --watch`, `gh run watch`, a polling loop, or any command that waits for sibling workflows or jobs.
+            - Never run \`gh pr checks --watch\`, \`gh run watch\`, a polling loop, or any command that waits for sibling workflows or jobs.
             - You may inspect check state once for diagnostic context. Pending sibling checks are not a review blocker and must not delay your decision.
             - Review and verify the exact diff with commands that can complete inside this job, emit the structured decision marker, and exit promptly so queued checks can run.
 

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -33,7 +33,7 @@ jobs:
           set -euo pipefail
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
           sudo apt-get update
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck zsh
 
       - name: Validate workflow library
         shell: bash

--- a/scripts/test-linux-runner-scheduling.zsh
+++ b/scripts/test-linux-runner-scheduling.zsh
@@ -1,0 +1,45 @@
+#!/bin/zsh
+set -eu
+
+export TRIPS_LINUX_TART_CONTROLLER_SOURCE_ONLY=1
+export TRIPS_LINUX_TART_REPOSITORIES="jai/trips-api,jai/trips-frontend,jai/trips-ci"
+
+source "${0:A:h}/trips-linux-tart-runner-controller.zsh"
+
+typeset -ga queued_repositories
+
+repository_has_queued_job() {
+  local candidate="$1"
+  (( ${queued_repositories[(Ie)$candidate]} > 0 ))
+}
+
+assert_selected() {
+  local expected="$1"
+  next_repository
+  if [[ "$selected_repository" != "$expected" ]]; then
+    print -u2 -r -- "expected ${expected}, selected ${selected_repository}"
+    return 1
+  fi
+}
+
+queued_repositories=(jai/trips-api jai/trips-frontend)
+assert_selected jai/trips-api
+assert_selected jai/trips-frontend
+assert_selected jai/trips-api
+
+queued_repositories=(jai/trips-frontend)
+assert_selected jai/trips-frontend
+
+queued_repositories=(jai/trips-api jai/trips-frontend jai/trips-ci)
+assert_selected jai/trips-ci
+assert_selected jai/trips-api
+assert_selected jai/trips-frontend
+
+queued_repositories=()
+if next_repository; then
+  print -u2 -r -- "expected no repository, selected ${selected_repository}"
+  exit 1
+fi
+[[ -z "$selected_repository" ]]
+
+print -r -- "linux runner scheduling tests passed"

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -6,6 +6,7 @@ PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 readonly app_id="${TRIPS_TART_GITHUB_APP_ID:-4452026}"
 readonly installation_id="${TRIPS_TART_GITHUB_INSTALLATION_ID:-150444191}"
 readonly repositories="${TRIPS_LINUX_TART_REPOSITORIES:-jai/trips-api,jai/trips-frontend,jai/trips-email-ingest-worker,jai/trips-infra,jai/trips,jai/trips-ci,jai/trips-fastlane,jai/openclaw-prompts}"
+readonly -a repository_list=(${(s:,:)repositories})
 readonly base_vm="${TRIPS_LINUX_TART_BASE_VM:-trips-linux-runner-base}"
 readonly base_memory_mb="${TRIPS_LINUX_TART_BASE_MEMORY_MB:-4096}"
 readonly runner_root="/opt/actions-runner"
@@ -18,7 +19,8 @@ readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
-mkdir -p "$log_directory"
+typeset -gi next_repository_index=1
+typeset -g selected_repository=""
 
 timestamp() {
   /bin/date -u '+%Y-%m-%dT%H:%M:%SZ'
@@ -89,9 +91,17 @@ repository_has_queued_job() {
 
 next_repository() {
   local repository
-  for repository in ${(s:,:)repositories}; do
+  local -i repository_count offset candidate_index
+  repository_count=${#repository_list}
+  selected_repository=""
+  (( repository_count > 0 )) || return 1
+
+  for (( offset = 0; offset < repository_count; offset++ )); do
+    candidate_index=$(( ((next_repository_index - 1 + offset) % repository_count) + 1 ))
+    repository="${repository_list[$candidate_index]}"
     if repository_has_queued_job "$repository"; then
-      printf '%s' "$repository"
+      selected_repository="$repository"
+      next_repository_index=$(( (candidate_index % repository_count) + 1 ))
       return 0
     fi
   done
@@ -238,6 +248,7 @@ run_one_ephemeral_runner() {
 main() {
   local repository
   umask 077
+  mkdir -p "$log_directory"
   if [[ -n "$required_volume" ]] && ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
     log "required volume ${required_volume} is not mounted"
     return 1
@@ -271,7 +282,8 @@ main() {
   done < <(/opt/homebrew/bin/tart list --source local --quiet)
 
   while true; do
-    if repository=$(next_repository); then
+    if next_repository; then
+      repository="$selected_repository"
       if run_one_ephemeral_runner "$repository"; then
         log "ephemeral runner completed a job for ${repository}"
       else
@@ -284,4 +296,6 @@ main() {
   done
 }
 
-main
+if [[ "${TRIPS_LINUX_TART_CONTROLLER_SOURCE_ONLY:-0}" != "1" ]]; then
+  main
+fi

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -27,6 +27,8 @@ actionlint "${actionlint_args[@]}" "$repo_root"/.github/workflows/*.yaml
 actionlint "${actionlint_args[@]}" "$tmp_dir/.github/workflows"/*.yaml
 actionlint "${actionlint_args[@]}" "$repo_root"/templates/*.yaml
 shellcheck "$repo_root/scripts/generate-caller-workflows.sh" "$repo_root/scripts/validate-workflows.sh"
+zsh -n "$repo_root/scripts/trips-linux-tart-runner-controller.zsh"
+"$repo_root/scripts/test-linux-runner-scheduling.zsh"
 
 if rg -n 'Claude PR Assistant|@claude|CLAUDE_' \
   "$repo_root/.github/workflows" \


### PR DESCRIPTION
## Summary
- retain the Linux Tart repository cursor in the controller parent shell
- rotate the next scan after every selected repository so earlier repos cannot starve later ones
- make source-only loading side-effect-free and add deterministic continuous/sparse/empty queue coverage
- prevent full-review agents from watching sibling checks while they own the sole Linux runner
- preserve the liveness commands literally in the generated review prompt

## Related Issue
Closes #108

## Validation
- `scripts/test-linux-runner-scheduling.zsh`
- `scripts/validate-workflows.sh`
- clean-shell parent-state probe (`a:2 → b:3 → a:2`)
- ARM64 Debian container source-only test
- prompt-expansion probe preserves literal no-watch commands
- independent exact-head `gpt-5.6-sol` xhigh review with Fast Mode disabled: APPROVE at `bca3eb7ace3d189968ba2eb735b5c86578544848`