### PR TITLE
fix(ci): prioritize oldest Linux runner queue

### DIFF
--- a/scripts/test-linux-runner-scheduling.zsh
+++ b/scripts/test-linux-runner-scheduling.zsh
@@ -6,6 +6,16 @@ export TRIPS_LINUX_TART_REPOSITORIES="jai/trips-api,jai/trips-frontend,jai/trips
 
 source "${0:A:h}/trips-linux-tart-runner-controller.zsh"
 
+if [[ -o pipefail ]]; then
+  print -u2 -r -- "controller source must not enable pipefail globally"
+  exit 1
+fi
+printf '%s' probe | base64url >/dev/null
+if [[ -o pipefail ]]; then
+  print -u2 -r -- "pipeline helpers must restore the caller's pipefail setting"
+  exit 1
+fi
+
 typeset -g api_queued_at=""
 typeset -g frontend_queued_at=""
 typeset -g ci_queued_at=""

--- a/scripts/test-linux-runner-scheduling.zsh
+++ b/scripts/test-linux-runner-scheduling.zsh
@@ -15,6 +15,15 @@ if [[ -o pipefail ]]; then
   print -u2 -r -- "pipeline helpers must restore the caller's pipefail setting"
   exit 1
 fi
+typeset production_base64url="${functions[base64url]}"
+base64url() {
+  return 7
+}
+if github_jwt >/dev/null 2>&1; then
+  print -u2 -r -- "JWT generation must preserve encoding failures"
+  exit 1
+fi
+functions[base64url]="$production_base64url"
 
 typeset -g api_queued_at=""
 typeset -g frontend_queued_at=""

--- a/scripts/test-linux-runner-scheduling.zsh
+++ b/scripts/test-linux-runner-scheduling.zsh
@@ -6,36 +6,49 @@ export TRIPS_LINUX_TART_REPOSITORIES="jai/trips-api,jai/trips-frontend,jai/trips
 
 source "${0:A:h}/trips-linux-tart-runner-controller.zsh"
 
-typeset -ga queued_repositories
+typeset -g api_queued_at=""
+typeset -g frontend_queued_at=""
+typeset -g ci_queued_at=""
 
-repository_has_queued_job() {
+repository_oldest_queued_job_timestamp() {
   local candidate="$1"
-  (( ${queued_repositories[(Ie)$candidate]} > 0 ))
+  case "$candidate" in
+    jai/trips-api) [[ -n "$api_queued_at" ]] && print -r -- "$api_queued_at" ;;
+    jai/trips-frontend) [[ -n "$frontend_queued_at" ]] && print -r -- "$frontend_queued_at" ;;
+    jai/trips-ci) [[ -n "$ci_queued_at" ]] && print -r -- "$ci_queued_at" ;;
+    *) return 1 ;;
+  esac
 }
 
 assert_selected() {
   local expected="$1"
-  next_repository
+  if ! next_repository; then
+    print -u2 -r -- "expected ${expected}, selected no repository"
+    return 1
+  fi
   if [[ "$selected_repository" != "$expected" ]]; then
     print -u2 -r -- "expected ${expected}, selected ${selected_repository}"
     return 1
   fi
 }
 
-queued_repositories=(jai/trips-api jai/trips-frontend)
-assert_selected jai/trips-api
-assert_selected jai/trips-frontend
-assert_selected jai/trips-api
-
-queued_repositories=(jai/trips-frontend)
+api_queued_at=2026-08-24T19:00:00Z
+frontend_queued_at=2026-08-24T18:00:00Z
+ci_queued_at=""
 assert_selected jai/trips-frontend
 
-queued_repositories=(jai/trips-api jai/trips-frontend jai/trips-ci)
-assert_selected jai/trips-ci
-assert_selected jai/trips-api
+api_queued_at=""
+frontend_queued_at=2026-08-24T18:00:00Z
 assert_selected jai/trips-frontend
 
-queued_repositories=()
+api_queued_at=2026-08-24T18:00:00Z
+frontend_queued_at=2026-08-24T18:00:00Z
+ci_queued_at=2026-08-24T18:00:00Z
+assert_selected jai/trips-api
+
+api_queued_at=""
+frontend_queued_at=""
+ci_queued_at=""
 if next_repository; then
   print -u2 -r -- "expected no repository, selected ${selected_repository}"
   exit 1

--- a/scripts/test-linux-runner-scheduling.zsh
+++ b/scripts/test-linux-runner-scheduling.zsh
@@ -9,6 +9,7 @@ source "${0:A:h}/trips-linux-tart-runner-controller.zsh"
 typeset -g api_queued_at=""
 typeset -g frontend_queued_at=""
 typeset -g ci_queued_at=""
+typeset production_repository_oldest_queued_job_timestamp="${functions[repository_oldest_queued_job_timestamp]}"
 
 repository_oldest_queued_job_timestamp() {
   local candidate="$1"
@@ -54,5 +55,34 @@ if next_repository; then
   exit 1
 fi
 [[ -z "$selected_repository" ]]
+
+functions[repository_oldest_queued_job_timestamp]="$production_repository_oldest_queued_job_timestamp"
+
+repository_workflow_runs() {
+  local candidate="$1"
+  case "$candidate" in
+    jai/trips-api)
+      print -r -- $'api-new\t2026-08-24T19:00:00Z'
+      print -r -- $'api-old\t2026-08-23T18:00:00Z'
+      ;;
+    jai/trips-frontend)
+      print -r -- $'frontend-run\t2026-08-24T18:00:00Z'
+      ;;
+  esac
+}
+
+workflow_run_oldest_queued_job_timestamp() {
+  local candidate="$1" run_id="$2"
+  case "${candidate}:${run_id}" in
+    jai/trips-api:api-new) print -r -- 2026-08-24T19:00:01Z ;;
+    jai/trips-api:api-old) print -r -- 2026-08-24T20:00:00Z ;;
+    jai/trips-frontend:frontend-run) print -r -- 2026-08-24T18:00:01Z ;;
+    *) return 1 ;;
+  esac
+}
+
+[[ "$(repository_oldest_queued_job_timestamp jai/trips-api)" == 2026-08-24T19:00:01Z ]]
+[[ "$(repository_oldest_queued_job_timestamp jai/trips-frontend)" == 2026-08-24T18:00:01Z ]]
+[[ -z "$(repository_oldest_queued_job_timestamp jai/trips-ci || true)" ]]
 
 print -r -- "linux runner scheduling tests passed"

--- a/scripts/test-linux-runner-scheduling.zsh
+++ b/scripts/test-linux-runner-scheduling.zsh
@@ -85,4 +85,20 @@ workflow_run_oldest_queued_job_timestamp() {
 [[ "$(repository_oldest_queued_job_timestamp jai/trips-frontend)" == 2026-08-24T18:00:01Z ]]
 [[ -z "$(repository_oldest_queued_job_timestamp jai/trips-ci || true)" ]]
 
+repository_workflow_runs() {
+  return 2
+}
+if repository_oldest_queued_job_timestamp jai/trips-api; then
+  print -u2 -r -- "expected repository lookup to preserve API failure"
+  exit 1
+else
+  [[ $? -eq 2 ]]
+fi
+if next_repository; then
+  print -u2 -r -- "expected scheduler to preserve API failure"
+  exit 1
+else
+  [[ $? -eq 2 ]]
+fi
+
 print -r -- "linux runner scheduling tests passed"

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -41,10 +41,10 @@ github_jwt() {
   now=$(/bin/date +%s)
   issued_at=$((now - 60))
   expires_at=$((now + 540))
-  header=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | base64url)
-  payload=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$issued_at" "$expires_at" "$app_id" | base64url)
+  header=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | base64url) || return 1
+  payload=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$issued_at" "$expires_at" "$app_id" | base64url) || return 1
   unsigned="${header}.${payload}"
-  signature=$(printf '%s' "$unsigned" | /usr/bin/openssl dgst -sha256 -sign "$private_key" | base64url)
+  signature=$(printf '%s' "$unsigned" | /usr/bin/openssl dgst -sha256 -sign "$private_key" | base64url) || return 1
   printf '%s.%s' "$unsigned" "$signature"
 }
 

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -1,5 +1,6 @@
 #!/bin/zsh
 set -u
+set -o pipefail
 
 PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
@@ -72,7 +73,7 @@ repository_workflow_runs() {
       -H 'Accept: application/vnd.github+json' \
       -H 'X-GitHub-Api-Version: 2022-11-28' \
       "repos/${repository}/actions/runs?status=${run_status}&per_page=100" \
-      --jq '.workflow_runs[] | [.id, .created_at] | @tsv'
+      --jq '.workflow_runs[] | [.id, .created_at] | @tsv' || return 2
   done
 }
 
@@ -82,31 +83,39 @@ workflow_run_oldest_queued_job_timestamp() {
     -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
-    /usr/bin/jq -r '[.[].jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci"))) | .created_at] | min // empty'
+    /usr/bin/jq -r '[.[].jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci"))) | .created_at] | min // empty' || return 2
 }
 
 repository_oldest_queued_job_timestamp() {
-  local repository="$1" run_id run_created_at queued_at oldest_queued_at
+  local repository="$1" runs run_id run_created_at queued_at oldest_queued_at
   oldest_queued_at=""
+  runs=$(repository_workflow_runs "$repository") || return 2
   while IFS=$'\t' read -r run_id run_created_at; do
     [[ -n "$run_id" ]] || continue
-    queued_at=$(workflow_run_oldest_queued_job_timestamp "$repository" "$run_id") || continue
+    queued_at=$(workflow_run_oldest_queued_job_timestamp "$repository" "$run_id") || return 2
     [[ -n "$queued_at" ]] || continue
     if [[ -z "$oldest_queued_at" || "$queued_at" < "$oldest_queued_at" ]]; then
       oldest_queued_at="$queued_at"
     fi
-  done < <(repository_workflow_runs "$repository")
+  done <<< "$runs"
   [[ -n "$oldest_queued_at" ]] || return 1
   print -r -- "$oldest_queued_at"
 }
 
 next_repository() {
   local repository queued_at oldest_queued_at
+  local -i lookup_status
   selected_repository=""
   oldest_queued_at=""
 
   for repository in "${repository_list[@]}"; do
-    queued_at=$(repository_oldest_queued_job_timestamp "$repository") || continue
+    if queued_at=$(repository_oldest_queued_job_timestamp "$repository"); then
+      :
+    else
+      lookup_status=$?
+      (( lookup_status == 1 )) && continue
+      return "$lookup_status"
+    fi
     if [[ -z "$oldest_queued_at" || "$queued_at" < "$oldest_queued_at" ]]; then
       selected_repository="$repository"
       oldest_queued_at="$queued_at"
@@ -254,6 +263,7 @@ run_one_ephemeral_runner() {
 
 main() {
   local repository
+  local -i scan_status
   umask 077
   mkdir -p "$log_directory"
   if [[ -n "$required_volume" ]] && ! /sbin/mount | /usr/bin/grep -Fq " on ${required_volume} ("; then
@@ -298,7 +308,13 @@ main() {
         /bin/sleep 15
       fi
     else
-      /bin/sleep "$idle_scan_interval_seconds"
+      scan_status=$?
+      if (( scan_status == 1 )); then
+        /bin/sleep "$idle_scan_interval_seconds"
+      else
+        log "GitHub queue scan failed; retrying in 15 seconds"
+        /bin/sleep 15
+      fi
     fi
   done
 }

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -16,6 +16,7 @@ readonly private_key="/Users/jai/.config/trips-tart-runner/github-app-private-ke
 readonly ssh_key="/Users/jai/.config/trips-tart-runner/runner-controller-ed25519"
 readonly log_directory="/Users/jai/Library/Logs/trips-linux-tart-runner"
 readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
+readonly idle_scan_interval_seconds="${TRIPS_LINUX_TART_IDLE_SCAN_INTERVAL_SECONDS:-30}"
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
@@ -64,32 +65,39 @@ registration_token() {
     /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
 }
 
-repository_oldest_queued_job_timestamp() {
-  local repository="$1" run_status run_id created_at oldest_created_at
-  oldest_created_at=""
+repository_workflow_runs() {
+  local repository="$1" run_status
   for run_status in queued in_progress; do
-    while IFS=$'\t' read -r run_id created_at; do
-      [[ -n "$run_id" ]] || continue
-      if /opt/homebrew/bin/gh api \
-        -H 'Accept: application/vnd.github+json' \
-        -H 'X-GitHub-Api-Version: 2022-11-28' \
-        "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
-        --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length' |
-        /usr/bin/grep -qxv '0'; then
-        if [[ -z "$oldest_created_at" || "$created_at" < "$oldest_created_at" ]]; then
-          oldest_created_at="$created_at"
-        fi
-      fi
-    done < <(
-      /opt/homebrew/bin/gh api \
-        -H 'Accept: application/vnd.github+json' \
-        -H 'X-GitHub-Api-Version: 2022-11-28' \
-        "repos/${repository}/actions/runs?status=${run_status}&per_page=20" \
-        --jq '.workflow_runs[] | [.id, .created_at] | @tsv'
-    )
+    /opt/homebrew/bin/gh api --paginate \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "repos/${repository}/actions/runs?status=${run_status}&per_page=100" \
+      --jq '.workflow_runs[] | [.id, .created_at] | @tsv'
   done
-  [[ -n "$oldest_created_at" ]] || return 1
-  print -r -- "$oldest_created_at"
+}
+
+workflow_run_oldest_queued_job_timestamp() {
+  local repository="$1" run_id="$2"
+  /opt/homebrew/bin/gh api --paginate --slurp \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
+    /usr/bin/jq -r '[.[].jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci"))) | .created_at] | min // empty'
+}
+
+repository_oldest_queued_job_timestamp() {
+  local repository="$1" run_id run_created_at queued_at oldest_queued_at
+  oldest_queued_at=""
+  while IFS=$'\t' read -r run_id run_created_at; do
+    [[ -n "$run_id" ]] || continue
+    queued_at=$(workflow_run_oldest_queued_job_timestamp "$repository" "$run_id") || continue
+    [[ -n "$queued_at" ]] || continue
+    if [[ -z "$oldest_queued_at" || "$queued_at" < "$oldest_queued_at" ]]; then
+      oldest_queued_at="$queued_at"
+    fi
+  done < <(repository_workflow_runs "$repository")
+  [[ -n "$oldest_queued_at" ]] || return 1
+  print -r -- "$oldest_queued_at"
 }
 
 next_repository() {
@@ -290,7 +298,7 @@ main() {
         /bin/sleep 15
       fi
     else
-      /bin/sleep 5
+      /bin/sleep "$idle_scan_interval_seconds"
     fi
   done
 }

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -19,7 +19,6 @@ readonly required_volume="${TRIPS_LINUX_TART_REQUIRED_VOLUME:-}"
 
 export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 
-typeset -gi next_repository_index=1
 typeset -g selected_repository=""
 
 timestamp() {
@@ -65,10 +64,11 @@ registration_token() {
     /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
 }
 
-repository_has_queued_job() {
-  local repository="$1" run_status run_id
+repository_oldest_queued_job_timestamp() {
+  local repository="$1" run_status run_id created_at oldest_created_at
+  oldest_created_at=""
   for run_status in queued in_progress; do
-    while IFS= read -r run_id; do
+    while IFS=$'\t' read -r run_id created_at; do
       [[ -n "$run_id" ]] || continue
       if /opt/homebrew/bin/gh api \
         -H 'Accept: application/vnd.github+json' \
@@ -76,36 +76,35 @@ repository_has_queued_job() {
         "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
         --jq '[.jobs[] | select(.status == "queued") | select((.labels | index("self-hosted")) and (.labels | index("linux")) and (.labels | index("arm64")) and (.labels | index("jai-ci")))] | length' |
         /usr/bin/grep -qxv '0'; then
-        return 0
+        if [[ -z "$oldest_created_at" || "$created_at" < "$oldest_created_at" ]]; then
+          oldest_created_at="$created_at"
+        fi
       fi
     done < <(
       /opt/homebrew/bin/gh api \
         -H 'Accept: application/vnd.github+json' \
         -H 'X-GitHub-Api-Version: 2022-11-28' \
         "repos/${repository}/actions/runs?status=${run_status}&per_page=20" \
-        --jq '.workflow_runs[].id'
+        --jq '.workflow_runs[] | [.id, .created_at] | @tsv'
     )
   done
-  return 1
+  [[ -n "$oldest_created_at" ]] || return 1
+  print -r -- "$oldest_created_at"
 }
 
 next_repository() {
-  local repository
-  local -i repository_count offset candidate_index
-  repository_count=${#repository_list}
+  local repository queued_at oldest_queued_at
   selected_repository=""
-  (( repository_count > 0 )) || return 1
+  oldest_queued_at=""
 
-  for (( offset = 0; offset < repository_count; offset++ )); do
-    candidate_index=$(( ((next_repository_index - 1 + offset) % repository_count) + 1 ))
-    repository="${repository_list[$candidate_index]}"
-    if repository_has_queued_job "$repository"; then
+  for repository in "${repository_list[@]}"; do
+    queued_at=$(repository_oldest_queued_job_timestamp "$repository") || continue
+    if [[ -z "$oldest_queued_at" || "$queued_at" < "$oldest_queued_at" ]]; then
       selected_repository="$repository"
-      next_repository_index=$(( (candidate_index % repository_count) + 1 ))
-      return 0
+      oldest_queued_at="$queued_at"
     fi
   done
-  return 1
+  [[ -n "$selected_repository" ]]
 }
 
 delete_vm() {

--- a/scripts/trips-linux-tart-runner-controller.zsh
+++ b/scripts/trips-linux-tart-runner-controller.zsh
@@ -1,6 +1,5 @@
 #!/bin/zsh
 set -u
-set -o pipefail
 
 PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
@@ -32,10 +31,12 @@ log() {
 }
 
 base64url() {
+  setopt local_options pipe_fail
   /usr/bin/openssl base64 -A | /usr/bin/tr '+/' '-_' | /usr/bin/tr -d '='
 }
 
 github_jwt() {
+  setopt local_options pipe_fail
   local now issued_at expires_at header payload unsigned signature
   now=$(/bin/date +%s)
   issued_at=$((now - 60))
@@ -48,6 +49,7 @@ github_jwt() {
 }
 
 registration_token() {
+  setopt local_options pipe_fail
   local repository="$1" jwt installation_token
   jwt=$(github_jwt) || return 1
   installation_token=$(
@@ -78,6 +80,7 @@ repository_workflow_runs() {
 }
 
 workflow_run_oldest_queued_job_timestamp() {
+  setopt local_options pipe_fail
   local repository="$1" run_id="$2"
   /opt/homebrew/bin/gh api --paginate --slurp \
     -H 'Accept: application/vnd.github+json' \
@@ -140,6 +143,7 @@ runner_id() {
 }
 
 runner_is_busy() {
+  setopt local_options pipe_fail
   local repository="$1" runner_name="$2"
   /opt/homebrew/bin/gh api \
     -H 'Accept: application/vnd.github+json' \


### PR DESCRIPTION
## Summary
- select the repository whose oldest eligible self-hosted Linux job has waited longest
- paginate the full queued and in-progress workflow backlog and rank exact queued-job creation timestamps
- preserve configured repository order as the deterministic timestamp tie-break
- slow empty-queue scans to 30 seconds so correctness does not exhaust the GitHub REST budget

## Related Issue
Closes #110

## Validation
- `zsh -n scripts/trips-linux-tart-runner-controller.zsh`
- `scripts/test-linux-runner-scheduling.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`
- live queued-job timestamp query against `jai/trips-frontend` run `32762402598`
- independent exact-diff review found and verified fixes for pagination, job-age ranking, API error propagation, global-pipefail SIGPIPE behavior, and swallowed JWT encoding failures; final gpt-5.6-sol xhigh/Fast-disabled verdict is APPROVE at `efc4b79`