### PR TITLE
fix(ci): wait for guest package-manager readiness

### DIFF
--- a/scripts/provision-lima-runner-base.sh
+++ b/scripts/provision-lima-runner-base.sh
@@ -11,9 +11,13 @@ node_root="/usr/local/lib/nodejs"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends \
-  build-essential ca-certificates curl docker-compose-v2 docker.io gh git git-lfs jq rsync shellcheck unzip xz-utils
+  build-essential ca-certificates curl docker-compose-v2 docker.io gh git git-lfs jq psmisc rsync shellcheck unzip xz-utils
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+
+systemctl disable --now apt-daily.timer apt-daily-upgrade.timer
+systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
+systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
 
 systemctl enable --now docker
 if ! id -nG jai | tr ' ' '\n' | grep -qx docker; then

--- a/scripts/provision-lima-runner-base.sh
+++ b/scripts/provision-lima-runner-base.sh
@@ -9,15 +9,15 @@ runner_root="/opt/actions-runner"
 node_root="/usr/local/lib/nodejs"
 
 export DEBIAN_FRONTEND=noninteractive
+systemctl disable --now apt-daily.timer apt-daily-upgrade.timer
+systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
+systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
+
 apt-get update
 apt-get install -y --no-install-recommends \
   build-essential ca-certificates curl docker-compose-v2 docker.io gh git git-lfs jq psmisc rsync shellcheck unzip xz-utils
 apt-get clean
 rm -rf /var/lib/apt/lists/*
-
-systemctl disable --now apt-daily.timer apt-daily-upgrade.timer
-systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
-systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
 
 systemctl enable --now docker
 if ! id -nG jai | tr ' ' '\n' | grep -qx docker; then

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -31,6 +31,7 @@ readonly package_manager_probe_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAG
 typeset -g installation_token_value=""
 typeset -g installation_token_expires_at=0
 typeset -g selected_repository=""
+typeset -g active_timeout_pid=""
 
 export LIMA_HOME="${LIMA_HOME:-/Users/jai/.lima}"
 
@@ -322,22 +323,49 @@ package_manager_sleep() {
 }
 
 run_with_timeout() {
-  local timeout_seconds="$1"
+  local timeout_seconds="$1" timeout_pid timeout_status
   shift
   "$timeout_python" -c 'import os, signal, subprocess, sys
 timeout = float(sys.argv[1])
 process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+def stop(signum, _frame):
+    if process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+    raise SystemExit(128 + signum)
+for handled_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(handled_signal, stop)
 try:
     status = process.wait(timeout)
 except subprocess.TimeoutExpired:
-    os.killpg(process.pid, signal.SIGKILL)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
     process.wait()
     raise SystemExit(124)
-raise SystemExit(status if status >= 0 else 128 + (-status))' "$timeout_seconds" "$@"
+raise SystemExit(status if status >= 0 else 128 + (-status))' "$timeout_seconds" "$@" &
+  timeout_pid=$!
+  active_timeout_pid="$timeout_pid"
+  timeout_status=0
+  wait "$timeout_pid" || timeout_status=$?
+  [[ "$active_timeout_pid" == "$timeout_pid" ]] && active_timeout_pid=""
+  return "$timeout_status"
+}
+
+stop_active_timeout() {
+  local timeout_pid="$active_timeout_pid"
+  [[ -n "$timeout_pid" ]] || return 0
+  /bin/kill -TERM "$timeout_pid" 2>/dev/null || true
+  wait "$timeout_pid" 2>/dev/null || true
+  [[ "$active_timeout_pid" == "$timeout_pid" ]] && active_timeout_pid=""
 }
 
 wait_for_guest_package_manager() {
-  local vm_name="$1" started_at deadline now remaining probe_timeout probe_output probe_status sleep_seconds
+  local vm_name="$1" started_at deadline now remaining probe_timeout probe_status sleep_seconds
   package_manager_now
   started_at="$REPLY"
   deadline=$((started_at + package_manager_timeout_seconds))
@@ -357,20 +385,15 @@ wait_for_guest_package_manager() {
     fi
     probe_timeout="$package_manager_probe_timeout_seconds"
     (( probe_timeout > remaining )) && probe_timeout="$remaining"
-    if probe_output=$(run_with_timeout "$probe_timeout" \
+    probe_status=0
+    run_with_timeout "$probe_timeout" \
       "$lima_cli" shell "$vm_name" -- bash -lc \
-        'sudo -n bash -c '\''/usr/bin/fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; printf "%s\\n" "$?"'\'''); then
-      probe_status="${probe_output//$'\r'/}"
-    else
-      probe_status=$?
-      log "package-manager readiness command failed in ${vm_name} with status ${probe_status}"
-      return 1
-    fi
+        'sudo -n bash -c '\''/usr/bin/fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; status=$?; (( status == 1 )) && exit 10; exit "$status"'\''' || probe_status=$?
     case "$probe_status" in
       0) ;;
-      1) return 0 ;;
+      10) return 0 ;;
       *)
-        log "package-manager readiness probe failed in ${vm_name} with status ${probe_status}"
+        log "package-manager readiness command failed in ${vm_name} with status ${probe_status}"
         return 1
         ;;
     esac
@@ -407,12 +430,12 @@ run_one_ephemeral_runner() {
   cleanup() {
     cleanup_runner_vm "$repository" "$runner_name" "$vm_name"
   }
-  trap 'release_selection_lock; cleanup || exit 1; exit 130' INT TERM
+  trap 'stop_active_timeout; release_selection_lock; cleanup || exit 1; exit 130' INT TERM
 
   {
+    wait_for_guest_package_manager "$vm_name" || return 1
     "$lima_cli" shell "$vm_name" -- \
       bash -lc 'set -e; test "$(nproc)" = 3; test "$(free -g | awk '\''/^Mem:/{print $2}'\'')" -ge 7; docker info >/dev/null; docker compose version; test -x /opt/actions-runner/bin/Runner.Listener' || return 1
-    wait_for_guest_package_manager "$vm_name" || return 1
 
     registration_token "$repository" || return 1
     token="$REPLY"

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -20,7 +20,7 @@ readonly selection_lock="${LIMA_HOME:-/Users/jai/.lima}/.trips-linux-runner-sele
 readonly gh_cli="${TRIPS_LINUX_LIMA_GH_CLI:-/opt/homebrew/bin/gh}"
 readonly curl_cli="${TRIPS_LINUX_LIMA_CURL_CLI:-/usr/bin/curl}"
 readonly lima_cli="${TRIPS_LINUX_LIMA_CLI:-/opt/homebrew/bin/limactl}"
-readonly timeout_cli="${TRIPS_LINUX_LIMA_TIMEOUT_CLI:-/opt/homebrew/bin/gtimeout}"
+readonly timeout_python="${TRIPS_LINUX_LIMA_TIMEOUT_PYTHON:-/usr/bin/python3}"
 readonly claim_timeout_seconds="${TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-30}"
@@ -321,17 +321,32 @@ package_manager_sleep() {
   /bin/sleep "$1"
 }
 
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+  "$timeout_python" -c 'import os, signal, subprocess, sys
+timeout = float(sys.argv[1])
+process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+try:
+    status = process.wait(timeout)
+except subprocess.TimeoutExpired:
+    os.killpg(process.pid, signal.SIGKILL)
+    process.wait()
+    raise SystemExit(124)
+raise SystemExit(status if status >= 0 else 128 + (-status))' "$timeout_seconds" "$@"
+}
+
 wait_for_guest_package_manager() {
   local vm_name="$1" started_at deadline now remaining probe_timeout probe_output probe_status sleep_seconds
-  if ! "$timeout_cli" --signal=KILL "${package_manager_probe_timeout_seconds}s" \
-    "$lima_cli" shell "$vm_name" -- bash -lc \
-      'test -x /usr/bin/fuser && sudo -n true'; then
-    log "package-manager readiness preflight failed in ${vm_name}"
-    return 1
-  fi
   package_manager_now
   started_at="$REPLY"
   deadline=$((started_at + package_manager_timeout_seconds))
+  if ! run_with_timeout "$package_manager_timeout_seconds" \
+    "$lima_cli" shell "$vm_name" -- bash -lc \
+      'test -x /usr/bin/fuser && sudo -n true && sudo -n systemctl stop apt-daily.timer apt-daily-upgrade.timer && sudo -n systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service && sudo -n systemctl mask --runtime apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service'; then
+    log "package-manager readiness preflight failed in ${vm_name}"
+    return 1
+  fi
   while true; do
     package_manager_now
     now="$REPLY"
@@ -342,7 +357,7 @@ wait_for_guest_package_manager() {
     fi
     probe_timeout="$package_manager_probe_timeout_seconds"
     (( probe_timeout > remaining )) && probe_timeout="$remaining"
-    if probe_output=$("$timeout_cli" --signal=KILL "${probe_timeout}s" \
+    if probe_output=$(run_with_timeout "$probe_timeout" \
       "$lima_cli" shell "$vm_name" -- bash -lc \
         'sudo -n bash -c '\''/usr/bin/fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; printf "%s\\n" "$?"'\'''); then
       probe_status="${probe_output//$'\r'/}"

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -20,9 +20,13 @@ readonly selection_lock="${LIMA_HOME:-/Users/jai/.lima}/.trips-linux-runner-sele
 readonly gh_cli="${TRIPS_LINUX_LIMA_GH_CLI:-/opt/homebrew/bin/gh}"
 readonly curl_cli="${TRIPS_LINUX_LIMA_CURL_CLI:-/usr/bin/curl}"
 readonly lima_cli="${TRIPS_LINUX_LIMA_CLI:-/opt/homebrew/bin/limactl}"
+readonly timeout_cli="${TRIPS_LINUX_LIMA_TIMEOUT_CLI:-/opt/homebrew/bin/gtimeout}"
 readonly claim_timeout_seconds="${TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-30}"
+readonly package_manager_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS:-300}"
+readonly package_manager_poll_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS:-2}"
+readonly package_manager_probe_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS:-15}"
 
 typeset -g installation_token_value=""
 typeset -g installation_token_expires_at=0
@@ -309,6 +313,65 @@ resolve_runner_status() {
   esac
 }
 
+package_manager_now() {
+  REPLY=$(/bin/date +%s)
+}
+
+package_manager_sleep() {
+  /bin/sleep "$1"
+}
+
+wait_for_guest_package_manager() {
+  local vm_name="$1" started_at deadline now remaining probe_timeout probe_output probe_status sleep_seconds
+  if ! "$timeout_cli" --signal=KILL "${package_manager_probe_timeout_seconds}s" \
+    "$lima_cli" shell "$vm_name" -- bash -lc \
+      'test -x /usr/bin/fuser && sudo -n true'; then
+    log "package-manager readiness preflight failed in ${vm_name}"
+    return 1
+  fi
+  package_manager_now
+  started_at="$REPLY"
+  deadline=$((started_at + package_manager_timeout_seconds))
+  while true; do
+    package_manager_now
+    now="$REPLY"
+    remaining=$((deadline - now))
+    if (( remaining <= 0 )); then
+      log "package manager remained busy in ${vm_name} for ${package_manager_timeout_seconds}s"
+      return 1
+    fi
+    probe_timeout="$package_manager_probe_timeout_seconds"
+    (( probe_timeout > remaining )) && probe_timeout="$remaining"
+    if probe_output=$("$timeout_cli" --signal=KILL "${probe_timeout}s" \
+      "$lima_cli" shell "$vm_name" -- bash -lc \
+        'sudo -n bash -c '\''/usr/bin/fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; printf "%s\\n" "$?"'\'''); then
+      probe_status="${probe_output//$'\r'/}"
+    else
+      probe_status=$?
+      log "package-manager readiness command failed in ${vm_name} with status ${probe_status}"
+      return 1
+    fi
+    case "$probe_status" in
+      0) ;;
+      1) return 0 ;;
+      *)
+        log "package-manager readiness probe failed in ${vm_name} with status ${probe_status}"
+        return 1
+        ;;
+    esac
+    package_manager_now
+    now="$REPLY"
+    remaining=$((deadline - now))
+    if (( remaining <= 0 )); then
+      log "package manager remained busy in ${vm_name} for ${package_manager_timeout_seconds}s"
+      return 1
+    fi
+    sleep_seconds="$package_manager_poll_seconds"
+    (( sleep_seconds > remaining )) && sleep_seconds="$remaining"
+    package_manager_sleep "$sleep_seconds"
+  done
+}
+
 run_one_ephemeral_runner() {
   local repository="$1" suffix vm_name token runner_name runner_pid runner_status
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
@@ -334,6 +397,7 @@ run_one_ephemeral_runner() {
   {
     "$lima_cli" shell "$vm_name" -- \
       bash -lc 'set -e; test "$(nproc)" = 3; test "$(free -g | awk '\''/^Mem:/{print $2}'\'')" -ge 7; docker info >/dev/null; docker compose version; test -x /opt/actions-runner/bin/Runner.Listener' || return 1
+    wait_for_guest_package_manager "$vm_name" || return 1
 
     registration_token "$repository" || return 1
     token="$REPLY"

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -44,6 +44,26 @@ fake_lima="${test_directory}/limactl"
 cat > "$fake_lima" <<'SCRIPT'
 #!/bin/zsh
 set -eu
+if [[ "$*" == *'test -x /usr/bin/fuser'* ]]; then
+  [[ "${FAKE_PACKAGE_FUSER_EXISTS:-true}" == true ]] || exit 1
+  [[ "${FAKE_PACKAGE_SUDO_PREFLIGHT_OK:-true}" == true ]] || exit 1
+  exit 0
+fi
+if [[ "$*" == *'sudo -n bash -c '*'/usr/bin/fuser '* ]]; then
+  if [[ -n "${FAKE_PACKAGE_PROBE_SUDO_STATUS:-}" ]]; then
+    exit "$FAKE_PACKAGE_PROBE_SUDO_STATUS"
+  fi
+  if [[ -n "${FAKE_PACKAGE_LOCK_PROBE_STATUS:-}" ]]; then
+    print -r -- "$FAKE_PACKAGE_LOCK_PROBE_STATUS"
+    exit 0
+  fi
+  attempts_file="${FAKE_PACKAGE_LOCK_ATTEMPTS_FILE:?}"
+  attempts=$(cat "$attempts_file")
+  attempts=$((attempts + 1))
+  print -r -- "$attempts" > "$attempts_file"
+  (( attempts > ${FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS:-0} )) && print -r -- 1 || print -r -- 0
+  exit 0
+fi
 if [[ "$1" == list && "${FAKE_VM_INVENTORY_ERROR:-false}" == true ]]; then
   exit 42
 fi
@@ -58,14 +78,30 @@ exit 0
 SCRIPT
 chmod 700 "$fake_lima"
 
+fake_timeout="${test_directory}/gtimeout"
+cat > "$fake_timeout" <<'SCRIPT'
+#!/bin/zsh
+set -eu
+if [[ "${FAKE_PACKAGE_LOCK_PROBE_HANG:-false}" == true && "$*" == *'sudo -n bash -c '*'/usr/bin/fuser '* ]]; then
+  exit 124
+fi
+shift 2
+exec "$@"
+SCRIPT
+chmod 700 "$fake_timeout"
+
 export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
 export TRIPS_LINUX_LIMA_SLOT=a
 export TRIPS_LINUX_LIMA_GH_CLI="$fake_gh"
 export TRIPS_LINUX_LIMA_CURL_CLI="$fake_curl"
 export TRIPS_LINUX_LIMA_CLI="$fake_lima"
+export TRIPS_LINUX_LIMA_TIMEOUT_CLI="$fake_timeout"
 export TRIPS_LINUX_LIMA_REPOSITORIES='jai/tonegate,jai/trips-api,jai/trips-frontend'
 export TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS=1
 export TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS=0.1
+export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS=10
+export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS=4
+export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS=3
 source "${repo_root}/scripts/trips-linux-lima-runner-controller.zsh"
 installation_token_value=test-token
 installation_token_expires_at=4102444800
@@ -171,6 +207,88 @@ wait "$fake_runner_pid" 2>/dev/null || true
 fake_runner_pid=$!
 resolve_runner_status 1 "$fake_runner_pid" 'test-runner'
 assert_equal 23 "$REPLY"
+
+export FAKE_PACKAGE_LOCK_ATTEMPTS_FILE="${test_directory}/package-lock-attempts"
+typeset production_package_manager_now="${functions[package_manager_now]}"
+typeset production_package_manager_sleep="${functions[package_manager_sleep]}"
+typeset -g fake_package_manager_now=100
+typeset -ga fake_package_manager_sleeps=()
+package_manager_now() {
+  REPLY="$fake_package_manager_now"
+}
+package_manager_sleep() {
+  fake_package_manager_sleeps+=("$1")
+  fake_package_manager_now=$((fake_package_manager_now + $1))
+}
+
+print -r -- 0 > "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE"
+export FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS=2
+fake_package_manager_now=100
+fake_package_manager_sleeps=()
+wait_for_guest_package_manager 'test-vm'
+assert_equal 3 "$(cat "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE")"
+
+print -r -- 0 > "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE"
+export FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS=10000
+fake_package_manager_now=100
+fake_package_manager_sleeps=()
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected package-manager readiness to time out'
+  exit 1
+fi
+
+export FAKE_PACKAGE_LOCK_PROBE_STATUS=42
+fake_package_manager_now=100
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected a package-manager probe failure to fail closed'
+  exit 1
+fi
+unset FAKE_PACKAGE_LOCK_PROBE_STATUS
+
+export FAKE_PACKAGE_FUSER_EXISTS=false
+fake_package_manager_now=100
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected a missing fuser to fail closed'
+  exit 1
+fi
+unset FAKE_PACKAGE_FUSER_EXISTS
+
+export FAKE_PACKAGE_SUDO_PREFLIGHT_OK=false
+fake_package_manager_now=100
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected a sudo preflight failure to fail closed'
+  exit 1
+fi
+unset FAKE_PACKAGE_SUDO_PREFLIGHT_OK
+
+export FAKE_PACKAGE_PROBE_SUDO_STATUS=1
+fake_package_manager_now=100
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected a probe-time sudo failure to fail closed'
+  exit 1
+fi
+unset FAKE_PACKAGE_PROBE_SUDO_STATUS
+
+export FAKE_PACKAGE_LOCK_PROBE_HANG=true
+fake_package_manager_now=100
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected a hung package-manager probe to fail closed'
+  exit 1
+fi
+unset FAKE_PACKAGE_LOCK_PROBE_HANG
+
+print -r -- 0 > "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE"
+export FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS=10000
+fake_package_manager_now=100
+fake_package_manager_sleeps=()
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected the total package-manager deadline to fail closed'
+  exit 1
+fi
+assert_equal 3 "$(cat "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE")"
+assert_equal '4 4 2' "${fake_package_manager_sleeps[*]}"
+functions[package_manager_now]="$production_package_manager_now"
+functions[package_manager_sleep]="$production_package_manager_sleep"
 
 export FAKE_VM_PRESENT=true
 if delete_vm 'test-vm'; then

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -47,9 +47,17 @@ set -eu
 if [[ "$*" == *'test -x /usr/bin/fuser'* ]]; then
   [[ "${FAKE_PACKAGE_FUSER_EXISTS:-true}" == true ]] || exit 1
   [[ "${FAKE_PACKAGE_SUDO_PREFLIGHT_OK:-true}" == true ]] || exit 1
+  [[ "$*" == *'systemctl stop apt-daily.timer apt-daily-upgrade.timer'* ]] || exit 1
+  [[ "$*" == *'systemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service'* ]] || exit 1
+  [[ "$*" == *'systemctl mask --runtime apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service'* ]] || exit 1
+  [[ "${FAKE_PACKAGE_QUIESCE_OK:-true}" == true ]] || exit 1
+  print -r -- quiesced > "${FAKE_PACKAGE_QUIESCE_FILE:?}"
   exit 0
 fi
 if [[ "$*" == *'sudo -n bash -c '*'/usr/bin/fuser '* ]]; then
+  if [[ "${FAKE_PACKAGE_LOCK_PROBE_HANG:-false}" == true ]]; then
+    /bin/sleep 10
+  fi
   if [[ -n "${FAKE_PACKAGE_PROBE_SUDO_STATUS:-}" ]]; then
     exit "$FAKE_PACKAGE_PROBE_SUDO_STATUS"
   fi
@@ -78,30 +86,17 @@ exit 0
 SCRIPT
 chmod 700 "$fake_lima"
 
-fake_timeout="${test_directory}/gtimeout"
-cat > "$fake_timeout" <<'SCRIPT'
-#!/bin/zsh
-set -eu
-if [[ "${FAKE_PACKAGE_LOCK_PROBE_HANG:-false}" == true && "$*" == *'sudo -n bash -c '*'/usr/bin/fuser '* ]]; then
-  exit 124
-fi
-shift 2
-exec "$@"
-SCRIPT
-chmod 700 "$fake_timeout"
-
 export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
 export TRIPS_LINUX_LIMA_SLOT=a
 export TRIPS_LINUX_LIMA_GH_CLI="$fake_gh"
 export TRIPS_LINUX_LIMA_CURL_CLI="$fake_curl"
 export TRIPS_LINUX_LIMA_CLI="$fake_lima"
-export TRIPS_LINUX_LIMA_TIMEOUT_CLI="$fake_timeout"
 export TRIPS_LINUX_LIMA_REPOSITORIES='jai/tonegate,jai/trips-api,jai/trips-frontend'
 export TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS=1
 export TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS=0.1
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS=10
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS=4
-export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS=3
+export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS=1
 source "${repo_root}/scripts/trips-linux-lima-runner-controller.zsh"
 installation_token_value=test-token
 installation_token_expires_at=4102444800
@@ -209,6 +204,7 @@ resolve_runner_status 1 "$fake_runner_pid" 'test-runner'
 assert_equal 23 "$REPLY"
 
 export FAKE_PACKAGE_LOCK_ATTEMPTS_FILE="${test_directory}/package-lock-attempts"
+export FAKE_PACKAGE_QUIESCE_FILE="${test_directory}/package-manager-quiesced"
 typeset production_package_manager_now="${functions[package_manager_now]}"
 typeset production_package_manager_sleep="${functions[package_manager_sleep]}"
 typeset -g fake_package_manager_now=100
@@ -227,6 +223,7 @@ fake_package_manager_now=100
 fake_package_manager_sleeps=()
 wait_for_guest_package_manager 'test-vm'
 assert_equal 3 "$(cat "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE")"
+assert_equal quiesced "$(cat "$FAKE_PACKAGE_QUIESCE_FILE")"
 
 print -r -- 0 > "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE"
 export FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS=10000
@@ -260,6 +257,14 @@ if wait_for_guest_package_manager 'test-vm'; then
   exit 1
 fi
 unset FAKE_PACKAGE_SUDO_PREFLIGHT_OK
+
+export FAKE_PACKAGE_QUIESCE_OK=false
+fake_package_manager_now=100
+if wait_for_guest_package_manager 'test-vm'; then
+  print -u2 -- 'Expected an apt-service quiesce failure to fail closed'
+  exit 1
+fi
+unset FAKE_PACKAGE_QUIESCE_OK
 
 export FAKE_PACKAGE_PROBE_SUDO_STATUS=1
 fake_package_manager_now=100

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -62,15 +62,13 @@ if [[ "$*" == *'sudo -n bash -c '*'/usr/bin/fuser '* ]]; then
     exit "$FAKE_PACKAGE_PROBE_SUDO_STATUS"
   fi
   if [[ -n "${FAKE_PACKAGE_LOCK_PROBE_STATUS:-}" ]]; then
-    print -r -- "$FAKE_PACKAGE_LOCK_PROBE_STATUS"
-    exit 0
+    exit "$FAKE_PACKAGE_LOCK_PROBE_STATUS"
   fi
   attempts_file="${FAKE_PACKAGE_LOCK_ATTEMPTS_FILE:?}"
   attempts=$(cat "$attempts_file")
   attempts=$((attempts + 1))
   print -r -- "$attempts" > "$attempts_file"
-  (( attempts > ${FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS:-0} )) && print -r -- 1 || print -r -- 0
-  exit 0
+  (( attempts > ${FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS:-0} )) && exit 10 || exit 0
 fi
 if [[ "$1" == list && "${FAKE_VM_INVENTORY_ERROR:-false}" == true ]]; then
   exit 42
@@ -224,6 +222,68 @@ fake_package_manager_sleeps=()
 wait_for_guest_package_manager 'test-vm'
 assert_equal 3 "$(cat "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE")"
 assert_equal quiesced "$(cat "$FAKE_PACKAGE_QUIESCE_FILE")"
+
+timeout_command="${test_directory}/timeout-command"
+cat > "$timeout_command" <<'SCRIPT'
+#!/bin/zsh
+set -eu
+print -r -- $$ > "${FAKE_TIMEOUT_COMMAND_PID_FILE:?}"
+/bin/sleep 30 &
+print -r -- $! > "${FAKE_TIMEOUT_CHILD_PID_FILE:?}"
+wait
+SCRIPT
+chmod 700 "$timeout_command"
+timeout_lifecycle="${test_directory}/timeout-lifecycle"
+cat > "$timeout_lifecycle" <<SCRIPT
+#!/bin/zsh
+set -u
+export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
+export TRIPS_LINUX_LIMA_SLOT=a
+source '${repo_root}/scripts/trips-linux-lima-runner-controller.zsh'
+trap 'stop_active_timeout; exit 130' INT TERM
+(
+  while [[ ! -s "\${FAKE_TIMEOUT_COMMAND_PID_FILE}" || ! -s "\${FAKE_TIMEOUT_CHILD_PID_FILE}" ]]; do /bin/sleep 0.05; done
+  /bin/kill -TERM \$\$
+) &
+run_with_timeout 30 '${timeout_command}'
+SCRIPT
+chmod 700 "$timeout_lifecycle"
+export FAKE_TIMEOUT_COMMAND_PID_FILE="${test_directory}/timeout-command.pid"
+export FAKE_TIMEOUT_CHILD_PID_FILE="${test_directory}/timeout-child.pid"
+if "$timeout_lifecycle"; then
+  print -u2 -- 'Expected controller termination to interrupt the active timeout'
+  exit 1
+else
+  assert_equal 130 "$?"
+fi
+timeout_command_pid=$(cat "$FAKE_TIMEOUT_COMMAND_PID_FILE")
+timeout_child_pid=$(cat "$FAKE_TIMEOUT_CHILD_PID_FILE")
+if /bin/kill -0 "$timeout_command_pid" 2>/dev/null || /bin/kill -0 "$timeout_child_pid" 2>/dev/null; then
+  print -u2 -- 'Expected controller termination to reap the timeout process group'
+  exit 1
+fi
+
+fake_provision_bin="${test_directory}/provision-bin"
+mkdir -p "$fake_provision_bin"
+fake_provision_log="${test_directory}/provision-order.log"
+cat > "${fake_provision_bin}/systemctl" <<'SCRIPT'
+#!/bin/sh
+printf 'systemctl %s\n' "$*" >> "${FAKE_PROVISION_LOG:?}"
+SCRIPT
+cat > "${fake_provision_bin}/apt-get" <<'SCRIPT'
+#!/bin/sh
+printf 'apt-get %s\n' "$*" >> "${FAKE_PROVISION_LOG:?}"
+exit 99
+SCRIPT
+chmod 700 "${fake_provision_bin}/systemctl" "${fake_provision_bin}/apt-get"
+export FAKE_PROVISION_LOG="$fake_provision_log"
+if PATH="${fake_provision_bin}:/usr/bin:/bin" /bin/bash "${repo_root}/scripts/provision-lima-runner-base.sh"; then
+  print -u2 -- 'Expected the provision-order harness to stop at apt-get'
+  exit 1
+else
+  assert_equal 99 "$?"
+fi
+assert_equal $'systemctl disable --now apt-daily.timer apt-daily-upgrade.timer\nsystemctl stop apt-daily.service apt-daily-upgrade.service unattended-upgrades.service\nsystemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service unattended-upgrades.service\napt-get update' "$(cat "$fake_provision_log")"
 
 print -r -- 0 > "$FAKE_PACKAGE_LOCK_ATTEMPTS_FILE"
 export FAKE_PACKAGE_LOCK_BUSY_ATTEMPTS=10000


### PR DESCRIPTION
## Summary
- wait for Ubuntu package-manager locks to clear before registering an ephemeral Lima runner
- fail closed on missing fuser, sudo refusal, unexpected probe status, or probe timeout
- bound each probe and the total readiness wait

## Related Issue
Fixes #113

## Validation
- `zsh -n scripts/trips-linux-lima-runner-controller.zsh tests/trips-linux-lima-runner-controller-test.zsh`
- `zsh tests/trips-linux-lima-runner-controller-test.zsh`
- `bash scripts/validate-workflows.sh`

## Notes
- Frontend CI job 97622972643 failed before Playwright because `unattended-upgr` held `/var/lib/dpkg/lock-frontend`.
