### PR TITLE
fix(ci): close timeout launch race

### DIFF
--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -323,11 +323,20 @@ package_manager_sleep() {
 }
 
 run_with_timeout() {
-  local timeout_seconds="$1" timeout_pid timeout_status
+  local timeout_seconds="$1" timeout_pid timeout_status expected_parent_pid
   shift
-  "$timeout_python" -c 'import os, signal, subprocess, sys
-timeout = float(sys.argv[1])
-process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+  zmodload zsh/system || return 1
+  expected_parent_pid="$sysparams[pid]"
+  "$timeout_python" -c 'import os, signal, subprocess, sys, time
+expected_parent = int(sys.argv[1])
+timeout = float(sys.argv[2])
+handled_signals = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+if os.getppid() != expected_parent:
+    raise SystemExit(130)
+signal.pthread_sigmask(signal.SIG_BLOCK, handled_signals)
+if os.getppid() != expected_parent:
+    raise SystemExit(130)
+process = subprocess.Popen(sys.argv[3:], start_new_session=True)
 def stop(signum, _frame):
     if process.poll() is None:
         try:
@@ -336,18 +345,27 @@ def stop(signum, _frame):
             pass
         process.wait()
     raise SystemExit(128 + signum)
-for handled_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+for handled_signal in handled_signals:
     signal.signal(handled_signal, stop)
-try:
-    status = process.wait(timeout)
-except subprocess.TimeoutExpired:
+signal.pthread_sigmask(signal.SIG_UNBLOCK, handled_signals)
+deadline = time.monotonic() + timeout
+while True:
+    if os.getppid() != expected_parent:
+        stop(signal.SIGTERM, None)
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+        raise SystemExit(124)
     try:
-        os.killpg(process.pid, signal.SIGKILL)
-    except ProcessLookupError:
+        status = process.wait(min(remaining, 0.05))
+        break
+    except subprocess.TimeoutExpired:
         pass
-    process.wait()
-    raise SystemExit(124)
-raise SystemExit(status if status >= 0 else 128 + (-status))' "$timeout_seconds" "$@" &
+raise SystemExit(status if status >= 0 else 128 + (-status))' "$expected_parent_pid" "$timeout_seconds" "$@" &
   timeout_pid=$!
   active_timeout_pid="$timeout_pid"
   timeout_status=0

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -263,6 +263,47 @@ if /bin/kill -0 "$timeout_command_pid" 2>/dev/null || /bin/kill -0 "$timeout_chi
   exit 1
 fi
 
+timeout_parent_death="${test_directory}/timeout-parent-death"
+cat > "$timeout_parent_death" <<SCRIPT
+#!/bin/zsh
+set -u
+export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
+export TRIPS_LINUX_LIMA_SLOT=a
+source '${repo_root}/scripts/trips-linux-lima-runner-controller.zsh'
+run_with_timeout 30 '${timeout_command}'
+SCRIPT
+chmod 700 "$timeout_parent_death"
+rm -f "$FAKE_TIMEOUT_COMMAND_PID_FILE" "$FAKE_TIMEOUT_CHILD_PID_FILE"
+"$timeout_parent_death" &
+timeout_parent_pid=$!
+for _ in {1..100}; do
+  timeout_python_pid=$(/usr/bin/pgrep -P "$timeout_parent_pid" 2>/dev/null | /usr/bin/head -n 1 || true)
+  [[ -n "$timeout_python_pid" && -s "$FAKE_TIMEOUT_COMMAND_PID_FILE" && -s "$FAKE_TIMEOUT_CHILD_PID_FILE" ]] && break
+  /bin/sleep 0.02
+done
+if [[ -z "${timeout_python_pid:-}" ]]; then
+  print -u2 -- 'Expected timeout helper to start before parent-death test'
+  exit 1
+fi
+timeout_command_pid=$(cat "$FAKE_TIMEOUT_COMMAND_PID_FILE")
+timeout_child_pid=$(cat "$FAKE_TIMEOUT_CHILD_PID_FILE")
+/bin/kill -KILL "$timeout_parent_pid"
+wait "$timeout_parent_pid" 2>/dev/null || true
+for _ in {1..100}; do
+  if ! /bin/kill -0 "$timeout_python_pid" 2>/dev/null &&
+    ! /bin/kill -0 "$timeout_command_pid" 2>/dev/null &&
+    ! /bin/kill -0 "$timeout_child_pid" 2>/dev/null; then
+    break
+  fi
+  /bin/sleep 0.02
+done
+if /bin/kill -0 "$timeout_python_pid" 2>/dev/null ||
+  /bin/kill -0 "$timeout_command_pid" 2>/dev/null ||
+  /bin/kill -0 "$timeout_child_pid" 2>/dev/null; then
+  print -u2 -- 'Expected parent-death guard to reap the timeout process group'
+  exit 1
+fi
+
 fake_provision_bin="${test_directory}/provision-bin"
 mkdir -p "$fake_provision_bin"
 fake_provision_log="${test_directory}/provision-order.log"


### PR DESCRIPTION
## Summary
- block termination signals until the Python timeout helper owns its child process group
- detect hard parent death using the actual zsh process ID and reap the complete probe group
- add deterministic parent-death lifecycle coverage

## Evidence
- `zsh tests/trips-linux-lima-runner-controller-test.zsh` (pass, 4.27s)
- `bash scripts/validate-workflows.sh` (pass, 7.00s)
- exact-diff Codex review on byte-identical pre-rebase tree: APPROVE; exact rebased-head review follows

Follow-up to #112. Closes #113.