### PR TITLE
fix(ci): preserve wrapped command signal semantics

### DIFF
--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -21,6 +21,9 @@ readonly gh_cli="${TRIPS_LINUX_LIMA_GH_CLI:-/opt/homebrew/bin/gh}"
 readonly curl_cli="${TRIPS_LINUX_LIMA_CURL_CLI:-/usr/bin/curl}"
 readonly lima_cli="${TRIPS_LINUX_LIMA_CLI:-/opt/homebrew/bin/limactl}"
 readonly timeout_python="${TRIPS_LINUX_LIMA_TIMEOUT_PYTHON:-/usr/bin/python3}"
+readonly timeout_preexec_delay_seconds="${TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_DELAY_SECONDS:-0}"
+readonly timeout_preexec_ready_file="${TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_READY_FILE:-}"
+readonly timeout_preexec_release_file="${TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_RELEASE_FILE:-}"
 readonly claim_timeout_seconds="${TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-30}"
@@ -327,16 +330,89 @@ run_with_timeout() {
   shift
   zmodload zsh/system || return 1
   expected_parent_pid="$sysparams[pid]"
-  "$timeout_python" -c 'import os, signal, subprocess, sys, time
+  "$timeout_python" -c 'import os, select, signal, subprocess, sys, time
 expected_parent = int(sys.argv[1])
 timeout = float(sys.argv[2])
-handled_signals = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+preexec_delay = float(sys.argv[3])
+preexec_ready_file = sys.argv[4]
+preexec_release_file = sys.argv[5]
+handled_signals = (signal.SIGHUP, signal.SIGINT, signal.SIGQUIT, signal.SIGTERM)
 if os.getppid() != expected_parent:
     raise SystemExit(130)
+if hasattr(select, "kqueue"):
+    parent_watch = select.kqueue()
+    try:
+        parent_watch.control([
+            select.kevent(
+                expected_parent,
+                filter=select.KQ_FILTER_PROC,
+                flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+                fflags=select.KQ_NOTE_EXIT,
+            )
+        ], 0, 0)
+    except ProcessLookupError:
+        raise SystemExit(130)
+    def parent_exited():
+        return bool(parent_watch.control(None, 1, 0))
+    def parent_exited_now():
+        child_watch = select.kqueue()
+        try:
+            child_watch.control([
+                select.kevent(
+                    expected_parent,
+                    filter=select.KQ_FILTER_PROC,
+                    flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+                    fflags=select.KQ_NOTE_EXIT,
+                )
+            ], 0, 0)
+            return bool(child_watch.control(None, 1, 0))
+        except ProcessLookupError:
+            return True
+        finally:
+            child_watch.close()
+elif hasattr(os, "pidfd_open"):
+    try:
+        parent_watch = os.pidfd_open(expected_parent)
+    except ProcessLookupError:
+        raise SystemExit(130)
+    parent_poll = select.poll()
+    parent_poll.register(parent_watch, select.POLLIN)
+    def parent_exited():
+        return bool(parent_poll.poll(0))
+    def parent_exited_now():
+        try:
+            child_watch = os.pidfd_open(expected_parent)
+        except ProcessLookupError:
+            return True
+        try:
+            child_poll = select.poll()
+            child_poll.register(child_watch, select.POLLIN)
+            return bool(child_poll.poll(0))
+        finally:
+            os.close(child_watch)
+else:
+    raise RuntimeError("kernel-backed parent exit observation is unavailable")
 signal.pthread_sigmask(signal.SIG_BLOCK, handled_signals)
-if os.getppid() != expected_parent:
+if os.getppid() != expected_parent or parent_exited():
     raise SystemExit(130)
-process = subprocess.Popen(sys.argv[3:], start_new_session=True)
+def prepare_child():
+    for handled_signal in handled_signals:
+        signal.signal(handled_signal, signal.SIG_DFL)
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, handled_signals)
+    if preexec_ready_file:
+        with open(preexec_ready_file, "w", encoding="utf-8") as ready_file:
+            ready_file.write("ready\n")
+    while preexec_release_file and not os.path.exists(preexec_release_file):
+        time.sleep(0.01)
+    if preexec_delay > 0:
+        time.sleep(preexec_delay)
+    if parent_exited_now():
+        os._exit(130)
+process = subprocess.Popen(
+    sys.argv[6:],
+    start_new_session=True,
+    preexec_fn=prepare_child,
+)
 def stop(signum, _frame):
     if process.poll() is None:
         try:
@@ -365,7 +441,9 @@ while True:
         break
     except subprocess.TimeoutExpired:
         pass
-raise SystemExit(status if status >= 0 else 128 + (-status))' "$expected_parent_pid" "$timeout_seconds" "$@" &
+raise SystemExit(status if status >= 0 else 128 + (-status))' \
+    "$expected_parent_pid" "$timeout_seconds" "$timeout_preexec_delay_seconds" \
+    "$timeout_preexec_ready_file" "$timeout_preexec_release_file" "$@" &
   timeout_pid=$!
   active_timeout_pid="$timeout_pid"
   timeout_status=0

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -304,6 +304,105 @@ if /bin/kill -0 "$timeout_python_pid" 2>/dev/null ||
   exit 1
 fi
 
+blocked_signals=$(run_with_timeout 2 /usr/bin/python3 -c \
+  'import signal; print(" ".join(sorted(item.name for item in signal.pthread_sigmask(signal.SIG_BLOCK, []))))')
+assert_equal '' "$blocked_signals"
+for signal_spec in HUP:129 INT:130 QUIT:131 TERM:143; do
+  signal_name="${signal_spec%%:*}"
+  expected_status="${signal_spec#*:}"
+  if run_with_timeout 2 /usr/bin/python3 -c \
+    'import os, signal, sys; os.kill(os.getpid(), getattr(signal, "SIG" + sys.argv[1])); raise SystemExit(99)' \
+    "$signal_name" >/dev/null 2>&1; then
+    print -u2 -- "Expected ${signal_name} to terminate the wrapped command"
+    exit 1
+  else
+    assert_equal "$expected_status" "$?"
+  fi
+done
+
+timeout_prelaunch_started="${test_directory}/timeout-prelaunch-started"
+timeout_prelaunch_release="${test_directory}/timeout-prelaunch-release"
+timeout_prelaunch_target_started="${test_directory}/timeout-prelaunch-target-started"
+timeout_prelaunch_target="${test_directory}/timeout-prelaunch-target"
+cat > "$timeout_prelaunch_target" <<'SCRIPT'
+#!/bin/zsh
+set -eu
+print -r -- started > "${FAKE_TIMEOUT_PRELAUNCH_TARGET_STARTED:?}"
+SCRIPT
+chmod 700 "$timeout_prelaunch_target"
+timeout_prelaunch_parent="${test_directory}/timeout-prelaunch-parent"
+cat > "$timeout_prelaunch_parent" <<SCRIPT
+#!/bin/zsh
+set -u
+export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
+export TRIPS_LINUX_LIMA_SLOT=a
+export TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_READY_FILE='${timeout_prelaunch_started}'
+export TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_RELEASE_FILE='${timeout_prelaunch_release}'
+source '${repo_root}/scripts/trips-linux-lima-runner-controller.zsh'
+run_with_timeout 30 '${timeout_prelaunch_target}'
+SCRIPT
+chmod 700 "$timeout_prelaunch_parent"
+export FAKE_TIMEOUT_PRELAUNCH_TARGET_STARTED="$timeout_prelaunch_target_started"
+"$timeout_prelaunch_parent" &
+timeout_prelaunch_parent_pid=$!
+for _ in {1..100}; do
+  [[ -s "$timeout_prelaunch_started" ]] && break
+  /bin/sleep 0.02
+done
+if [[ ! -s "$timeout_prelaunch_started" ]]; then
+  print -u2 -- 'Expected delayed timeout helper to reach its pre-launch handshake'
+  exit 1
+fi
+timeout_prelaunch_python_pid=$(/usr/bin/pgrep -P "$timeout_prelaunch_parent_pid" | /usr/bin/head -n 1)
+if [[ -z "$timeout_prelaunch_python_pid" ]]; then
+  print -u2 -- 'Expected timeout helper to remain alive during the child pre-exec window'
+  exit 1
+fi
+timeout_prelaunch_child_pid=$(/usr/bin/pgrep -P "$timeout_prelaunch_python_pid" | /usr/bin/head -n 1)
+if [[ -z "$timeout_prelaunch_child_pid" ]]; then
+  print -u2 -- 'Expected wrapped child to wait at the pre-exec release barrier'
+  exit 1
+fi
+/bin/kill -STOP "$timeout_prelaunch_python_pid"
+for _ in {1..100}; do
+  timeout_prelaunch_python_state=$(/bin/ps -o state= -p "$timeout_prelaunch_python_pid" | /usr/bin/tr -d ' ')
+  [[ "$timeout_prelaunch_python_state" == T* ]] && break
+  /bin/sleep 0.02
+done
+if [[ "${timeout_prelaunch_python_state:-}" != T* ]]; then
+  /bin/kill -CONT "$timeout_prelaunch_python_pid" 2>/dev/null || true
+  print -u2 -- 'Expected timeout helper to stop before the pre-launch parent-death assertion'
+  exit 1
+fi
+/bin/kill -KILL "$timeout_prelaunch_parent_pid"
+print -r -- released > "$timeout_prelaunch_release"
+for _ in {1..100}; do
+  timeout_prelaunch_child_state=$(/bin/ps -o state= -p "$timeout_prelaunch_child_pid" 2>/dev/null | /usr/bin/tr -d ' ' || true)
+  [[ -z "$timeout_prelaunch_child_state" || "$timeout_prelaunch_child_state" == Z* ]] && break
+  /bin/sleep 0.02
+done
+if [[ -n "${timeout_prelaunch_child_state:-}" && "$timeout_prelaunch_child_state" != Z* ]]; then
+  /bin/kill -CONT "$timeout_prelaunch_python_pid" 2>/dev/null || true
+  print -u2 -- 'Expected wrapped child to finish after crossing the pre-exec release barrier'
+  exit 1
+fi
+timeout_prelaunch_target_was_started=false
+[[ -e "$timeout_prelaunch_target_started" ]] && timeout_prelaunch_target_was_started=true
+/bin/kill -CONT "$timeout_prelaunch_python_pid"
+if [[ "$timeout_prelaunch_target_was_started" == true ]]; then
+  print -u2 -- 'Expected the timeout target to remain unlaunched while its stopped helper cannot reap it'
+  exit 1
+fi
+for _ in {1..100}; do
+  ! /bin/kill -0 "$timeout_prelaunch_python_pid" 2>/dev/null && break
+  /bin/sleep 0.02
+done
+if /bin/kill -0 "$timeout_prelaunch_python_pid" 2>/dev/null; then
+  print -u2 -- 'Expected delayed timeout helper to exit after its parent died'
+  exit 1
+fi
+wait "$timeout_prelaunch_parent_pid" 2>/dev/null || true
+
 fake_provision_bin="${test_directory}/provision-bin"
 mkdir -p "$fake_provision_bin"
 fake_provision_log="${test_directory}/provision-order.log"


### PR DESCRIPTION
## Summary
- restore default HUP/INT/QUIT/TERM dispositions and unblock their masks in wrapped commands before exec
- observe controller exit through macOS kqueue NOTE_EXIT in production and Linux pidfd in validation
- define the child pre-exec liveness check as the launch linearization point and verify it through a deterministic release-file barrier

## Related Issue

Closes #113

## Validation
- `zsh tests/trips-linux-lima-runner-controller-test.zsh` (7.28s)
- `bash scripts/validate-workflows.sh` (7.95s)
- 5/5 mutation runs failed at the expected pre-exec assertion when only the final child-side liveness check was removed (17.5s)
- `git diff --check`

## Notes
Resolved exact-head review findings by moving the race handshake into `preexec_fn`, restoring/testing SIGQUIT, narrowing the guarantee to the final child-side liveness linearization point, and replacing timing-sensitive coverage with a release-file barrier plus explicit child-state observation. Follow-up to #114.