### PR TITLE
fix(ci): release runner lock before scan backoff

### DIFF
--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -26,7 +26,8 @@ readonly timeout_preexec_ready_file="${TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_READY_FI
 readonly timeout_preexec_release_file="${TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_RELEASE_FILE:-}"
 readonly claim_timeout_seconds="${TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
-readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-30}"
+readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-120}"
+readonly scan_failure_backoff_seconds="${TRIPS_LINUX_LIMA_SCAN_FAILURE_BACKOFF_SECONDS:-60}"
 readonly package_manager_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS:-300}"
 readonly package_manager_poll_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS:-2}"
 readonly package_manager_probe_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS:-15}"
@@ -250,6 +251,26 @@ release_selection_lock() {
   owner="$(/bin/cat "${selection_lock}/pid" 2>/dev/null || true)"
   if [[ "$owner" == "$$" ]]; then
     /bin/rm -rf "$selection_lock"
+  fi
+}
+
+selection_sleep() {
+  /bin/sleep "$1"
+}
+
+handle_no_selected_repository() {
+  local -i scan_status="$1"
+  # Keep the shared lock while idle so the second slot cannot duplicate the
+  # repository scan and exhaust the authenticated GitHub API quota. A failed
+  # scan is different: release the lock before backoff so one throttled lane
+  # cannot prevent the other lane from making progress.
+  if (( scan_status == 1 )); then
+    selection_sleep "$idle_scan_interval_seconds"
+    release_selection_lock
+  else
+    release_selection_lock
+    log "GitHub queue scan failed; retrying in ${scan_failure_backoff_seconds} seconds"
+    selection_sleep "$scan_failure_backoff_seconds"
   fi
 }
 
@@ -603,15 +624,7 @@ main() {
       fi
     else
       scan_status=$?
-      # Keep the shared lock while idle so the second slot cannot duplicate the
-      # repository scan and exhaust the authenticated GitHub API quota.
-      if (( scan_status == 1 )); then
-        /bin/sleep "$idle_scan_interval_seconds"
-      else
-        log "GitHub queue scan failed; retrying in 15 seconds"
-        /bin/sleep 15
-      fi
-      release_selection_lock
+      handle_no_selected_repository "$scan_status"
     fi
   done
 }

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -86,6 +86,7 @@ chmod 700 "$fake_lima"
 
 export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
 export TRIPS_LINUX_LIMA_SLOT=a
+export LIMA_HOME="${test_directory}/lima-home"
 export TRIPS_LINUX_LIMA_GH_CLI="$fake_gh"
 export TRIPS_LINUX_LIMA_CURL_CLI="$fake_curl"
 export TRIPS_LINUX_LIMA_CLI="$fake_lima"
@@ -96,6 +97,7 @@ export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS=10
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS=4
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS=1
 source "${repo_root}/scripts/trips-linux-lima-runner-controller.zsh"
+mkdir -p "$LIMA_HOME"
 installation_token_value=test-token
 installation_token_expires_at=4102444800
 
@@ -163,6 +165,41 @@ else
   assert_equal 2 "$?"
 fi
 functions[repository_oldest_queued_job_timestamp]="$production_repository_oldest_queued_job_timestamp"
+
+typeset production_selection_sleep="${functions[selection_sleep]}"
+typeset -ga observed_selection_lock_states=()
+typeset -ga observed_selection_sleep_durations=()
+selection_sleep() {
+  observed_selection_sleep_durations+=("$1")
+  if [[ -d "$selection_lock" ]]; then
+    observed_selection_lock_states+=(locked)
+  else
+    observed_selection_lock_states+=(unlocked)
+  fi
+}
+
+acquire_selection_lock
+observed_selection_lock_states=()
+observed_selection_sleep_durations=()
+handle_no_selected_repository 1
+assert_equal locked "${observed_selection_lock_states[1]}"
+assert_equal 120 "${observed_selection_sleep_durations[1]}"
+if [[ -d "$selection_lock" ]]; then
+  print -u2 -- 'Expected an empty healthy scan to release the selection lock after idle sleep'
+  exit 1
+fi
+
+acquire_selection_lock
+observed_selection_lock_states=()
+observed_selection_sleep_durations=()
+handle_no_selected_repository 2
+assert_equal unlocked "${observed_selection_lock_states[1]}"
+assert_equal 60 "${observed_selection_sleep_durations[1]}"
+if [[ -d "$selection_lock" ]]; then
+  print -u2 -- 'Expected a failed queue scan to release the selection lock before backoff'
+  exit 1
+fi
+functions[selection_sleep]="$production_selection_sleep"
 
 runner_lookup 'jai/tonegate' 'page-two-runner'
 assert_equal $'4242\tbusy' "$REPLY"


### PR DESCRIPTION
## Summary

- release the shared Linux runner selection lock before queue-scan failure backoff
- reduce healthy idle scan cadence from 30 seconds to 120 seconds and failure retry cadence from 15 seconds to 60 seconds
- execute deterministic lock-state and sleep-duration assertions for both healthy-empty and failed scans

## Related Issue

Closes #116

## Validation

- `zsh tests/trips-linux-lima-runner-controller-test.zsh`
- `bash scripts/validate-workflows.sh`
- mutation proof: removing the failure-path unlock fails immediately with `Expected unlocked, got locked`

## Notes

The production controller is not replaced by this PR itself. After merge, install the merged source and restart both idle controllers so no active runner VM or claimed job is interrupted.