### PR TITLE
fix(ci): accept empty Tart VM inventory

### DIFF
--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -269,6 +269,7 @@ list_ephemeral_vms() {
   while IFS= read -r vm_name; do
     [[ "$vm_name" == trips-runner-job-* ]] && print -r -- "$vm_name"
   done <<< "$inventory"
+  return 0
 }
 
 cleanup_runner_vm() {

--- a/tests/trips-tart-runner-controller-test.zsh
+++ b/tests/trips-tart-runner-controller-test.zsh
@@ -75,6 +75,9 @@ fi
 if [[ "$1" == list && "${FAKE_VM_PRESENT:-false}" == true ]]; then
   print -r -- 'test-vm'
 fi
+if [[ "$1" == list && "${FAKE_STALE_VM_PRESENT:-false}" == true ]]; then
+  print -r -- 'trips-runner-job-stale'
+fi
 exit 0
 SCRIPT
 chmod 700 "$fake_tart"
@@ -205,6 +208,14 @@ if cleanup_runner_vm 'jai/trips-frontend' 'test-runner' 'test-vm' "${test_direct
 fi
 export FAKE_VM_PRESENT=false
 delete_vm 'test-vm'
+empty_inventory=$(list_ephemeral_vms) || {
+  print -u2 -- 'Expected an empty Tart inventory to succeed with no stale VMs'
+  exit 1
+}
+assert_equal '' "$empty_inventory"
+export FAKE_STALE_VM_PRESENT=true
+assert_equal 'trips-runner-job-stale' "$(list_ephemeral_vms)"
+export FAKE_STALE_VM_PRESENT=false
 export FAKE_VM_INVENTORY_ERROR=true
 if delete_vm 'test-vm'; then
   print -u2 -- 'Expected Tart deletion to fail closed when inventory verification fails'


### PR DESCRIPTION
## Summary

- Make a successful empty Tart VM inventory a healthy startup state.
- Preserve fail-closed behavior when inventory cannot be read.
- Add deterministic empty, matching-stale, and inventory-error regression coverage.

## Related Issue

Closes #118

## Validation

- `./tests/trips-tart-runner-controller-test.zsh` — passed in 1.364s
- `bash scripts/validate-workflows.sh` — passed in 9.802s
- Independent exact-diff `gpt-5.6-sol` xhigh review with Fast Mode disabled — APPROVE
- Diff SHA-256: `440c9e43808c75b7b3beb4247511dab5c6ac5c3ed3350c4dec29c1451255a62b`