### PR TITLE
fix(ci): allow unprivileged Tart networking

### DIFF
--- a/scripts/start-trips-tart-runner.zsh
+++ b/scripts/start-trips-tart-runner.zsh
@@ -7,4 +7,5 @@ export TART_HOME="${TART_HOME:-/Users/jai/.tart}"
 export TRIPS_TART_RUNNER_HOST_LABEL="borg-cube-03"
 export TRIPS_TART_RUNNER_NAME_PREFIX="borg-cube-03-tart"
 export TRIPS_TART_WORK_DISK_DIRECTORY="${TRIPS_TART_WORK_DISK_DIRECTORY:-/Users/jai/.local/share/trips-tart-runner/work-disks}"
+export TRIPS_TART_NETWORK_MODE="${TRIPS_TART_NETWORK_MODE:-shared}"
 exec /Users/jai/.local/bin/trips-tart-runner-controller

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -26,6 +26,7 @@ readonly tart_cli="${TRIPS_TART_CLI:-/opt/homebrew/bin/tart}"
 readonly claim_timeout_seconds="${TRIPS_TART_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_TART_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_TART_IDLE_SCAN_INTERVAL_SECONDS:-30}"
+readonly network_mode="${TRIPS_TART_NETWORK_MODE:-softnet}"
 
 typeset -g installation_token_value=""
 typeset -g installation_token_expires_at=0
@@ -272,6 +273,23 @@ list_ephemeral_vms() {
   return 0
 }
 
+start_tart_vm() {
+  local vm_name="$1" work_disk="$2" vm_log="$3" requested_network_mode="${4:-$network_mode}"
+  local -a network_arguments
+  network_arguments=()
+  case "$requested_network_mode" in
+    shared) ;;
+    softnet) network_arguments=(--net-softnet) ;;
+    *)
+      log "unsupported Tart network mode ${requested_network_mode}"
+      return 1
+      ;;
+  esac
+  "$tart_cli" run --no-graphics --no-audio --no-clipboard \
+    "${network_arguments[@]}" --disk="${work_disk}:sync=none" "$vm_name" >"$vm_log" 2>&1 &
+  REPLY=$!
+}
+
 cleanup_runner_vm() {
   local repository="$1" runner_name="$2" vm_name="$3" work_disk="$4"
   log "deleting ${vm_name}"
@@ -346,9 +364,8 @@ run_one_ephemeral_runner() {
     /usr/sbin/mkfile -n 60g "$work_disk" || return 1
 
     log "starting ${vm_name}"
-    "$tart_cli" run --no-graphics --no-audio --no-clipboard --net-softnet \
-      --disk="${work_disk}:sync=none" "$vm_name" >"$vm_log" 2>&1 &
-    vm_pid=$!
+    start_tart_vm "$vm_name" "$work_disk" "$vm_log" || return 1
+    vm_pid="$REPLY"
     vm_ip=$("$tart_cli" ip "$vm_name" --wait 180) || return 1
     ssh_ready=false
     for _ in {1..60}; do

--- a/tests/trips-tart-runner-controller-test.zsh
+++ b/tests/trips-tart-runner-controller-test.zsh
@@ -69,6 +69,9 @@ fake_tart="${test_directory}/tart"
 cat > "$fake_tart" <<'SCRIPT'
 #!/bin/zsh
 set -eu
+if [[ -n "${FAKE_TART_RUN_LOG:-}" ]]; then
+  print -r -- "$*" >> "$FAKE_TART_RUN_LOG"
+fi
 if [[ "$1" == list && "${FAKE_VM_INVENTORY_ERROR:-false}" == true ]]; then
   exit 42
 fi
@@ -223,6 +226,42 @@ if delete_vm 'test-vm'; then
 fi
 if list_ephemeral_vms >/dev/null; then
   print -u2 -- 'Expected Tart startup inventory failure to propagate'
+  exit 1
+fi
+export FAKE_VM_INVENTORY_ERROR=false
+
+export FAKE_TART_RUN_LOG="${test_directory}/tart-run.log"
+assert_configured_network_invocation() {
+  local configured_mode="$1" vm_name="$2" expected_invocation="$3"
+  local work_disk="${test_directory}/${vm_name}.raw" vm_log="${test_directory}/${vm_name}.log"
+  : > "$FAKE_TART_RUN_LOG"
+  if [[ "$configured_mode" == unset ]]; then
+    env -u TRIPS_TART_NETWORK_MODE \
+      TRIPS_RUNNER_CONTROLLER_LIBRARY_ONLY=true \
+      TRIPS_TART_CLI="$fake_tart" \
+      FAKE_TART_RUN_LOG="$FAKE_TART_RUN_LOG" \
+      zsh -uc 'source "$1"; start_tart_vm "$2" "$3" "$4"; tart_pid="$REPLY"; wait "$tart_pid"' \
+      _ "${repo_root}/scripts/trips-tart-runner-controller.zsh" "$vm_name" "$work_disk" "$vm_log"
+  else
+    TRIPS_TART_NETWORK_MODE="$configured_mode" \
+      TRIPS_RUNNER_CONTROLLER_LIBRARY_ONLY=true \
+      TRIPS_TART_CLI="$fake_tart" \
+      FAKE_TART_RUN_LOG="$FAKE_TART_RUN_LOG" \
+      zsh -uc 'source "$1"; start_tart_vm "$2" "$3" "$4"; tart_pid="$REPLY"; wait "$tart_pid"' \
+      _ "${repo_root}/scripts/trips-tart-runner-controller.zsh" "$vm_name" "$work_disk" "$vm_log"
+  fi
+  assert_equal "$expected_invocation" "$(tail -n 1 "$FAKE_TART_RUN_LOG")"
+}
+
+assert_configured_network_invocation unset default-vm \
+  'run --no-graphics --no-audio --no-clipboard --net-softnet --disk='"${test_directory}/default-vm.raw"':sync=none default-vm'
+assert_configured_network_invocation shared shared-vm \
+  'run --no-graphics --no-audio --no-clipboard --disk='"${test_directory}/shared-vm.raw"':sync=none shared-vm'
+assert_configured_network_invocation softnet softnet-vm \
+  'run --no-graphics --no-audio --no-clipboard --net-softnet --disk='"${test_directory}/softnet-vm.raw"':sync=none softnet-vm'
+
+if start_tart_vm 'invalid-vm' "${test_directory}/invalid.raw" "${test_directory}/invalid.log" unsupported; then
+  print -u2 -- 'Expected an unsupported Tart network mode to fail closed'
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Preserve Softnet as the controller-wide default.
- Configure the Borg launch agent to use Tart shared networking, which works without passwordless root.
- Exercise the production three-argument VM start path with deterministic fake-Tart tests for unset, shared, softnet, and invalid modes.

## Related Issue
Closes #120

## Validation
- TDD red: controller test failed because start_tart_vm did not exist.
- Focused controller test passed in 2.313s.
- Full bash scripts/validate-workflows.sh passed in 10.021s.
- Live Borg shared-NAT probe booted, obtained 192.168.64.52, and returned Xcode 26.6 over SSH.
- Independent exact-diff review: gpt-5.6-sol, xhigh, Fast Mode disabled, final APPROVE (session 01a037fa-d50f-7733-9d1d-8d77205fe344).