### PR TITLE
feat(ci): provision a recoverable iOS Tart base candidate

### DIFF
--- a/scripts/provision-tart-runner-base.zsh
+++ b/scripts/provision-tart-runner-base.zsh
@@ -1,0 +1,64 @@
+#!/bin/zsh
+set -euo pipefail
+
+PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+readonly base_vm="${TRIPS_TART_BASE_VM:-trips-runner-base-next}"
+readonly source_image="${TRIPS_TART_BASE_SOURCE_IMAGE:-ghcr.io/cirruslabs/macos-tahoe-xcode:latest}"
+readonly base_cpus="${TRIPS_TART_BASE_CPUS:-4}"
+readonly base_memory_mb="${TRIPS_TART_BASE_MEMORY_MB:-16384}"
+readonly base_disk_gib="${TRIPS_TART_BASE_DISK_GIB:-120}"
+readonly minimum_root_free_gib="${TRIPS_TART_MINIMUM_ROOT_FREE_GIB:-5}"
+readonly tart_cli="${TRIPS_TART_CLI:-/opt/homebrew/bin/tart}"
+
+timestamp() {
+  /bin/date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+phase() {
+  print -- "$(timestamp) phase=$1"
+}
+
+base_name_is_safe() {
+  [[ "$1" != trips-runner-base && "$1" != trips-runner-base-pre-apfs-expand ]]
+}
+
+base_root_preflight_command() {
+  printf '%s' 'set -e; test "$(df -g / | awk '\''NR == 2 {print $4}'\'')" -ge "${TRIPS_TART_MINIMUM_ROOT_FREE_GIB:-5}"; xcodebuild -version >/dev/null; java -version >/dev/null 2>&1; test -x /Users/admin/actions-runner/bin/Runner.Listener; xcrun simctl list runtimes | grep -q "iOS"'
+}
+
+verify_base() {
+  "$tart_cli" list --source local --quiet | /usr/bin/grep -qx "$base_vm" || {
+    print -u2 -- "Candidate Tart base is missing: ${base_vm}"
+    return 1
+  }
+  phase guest-root-preflight
+  "$tart_cli" exec "$base_vm" /bin/zsh -lc "$(base_root_preflight_command)"
+  phase guest-root-preflight-complete
+}
+
+main() {
+  if [[ "${1:-}" == --verify ]]; then
+    verify_base
+    return
+  fi
+  base_name_is_safe "$base_vm" || {
+    print -u2 -- "Refusing to overwrite a live or rollback Tart base: ${base_vm}"
+    return 1
+  }
+  "$tart_cli" list --source local --quiet | /usr/bin/grep -qx "$base_vm" && {
+    print -u2 -- "Candidate Tart base already exists: ${base_vm}"
+    return 1
+  }
+
+  phase clone-source-image
+  "$tart_cli" clone "$source_image" "$base_vm"
+  phase configure-candidate
+  "$tart_cli" set "$base_vm" --cpu "$base_cpus" --memory "$base_memory_mb" --disk-size "$base_disk_gib"
+  phase candidate-created
+  print -- "Created ${base_vm} from ${source_image}."
+}
+
+if [[ "${TRIPS_TART_BASE_LIBRARY_ONLY:-false}" != true ]]; then
+  main "$@"
+fi

--- a/scripts/validate-workflows.sh
+++ b/scripts/validate-workflows.sh
@@ -30,13 +30,16 @@ shellcheck "$repo_root/scripts/generate-caller-workflows.sh" "$repo_root/scripts
 shellcheck "$repo_root/scripts/provision-lima-runner-base.sh"
 zsh -n \
   "$repo_root/scripts/provision-lima-runner-base.zsh" \
+  "$repo_root/scripts/provision-tart-runner-base.zsh" \
   "$repo_root/scripts/start-trips-linux-lima-runner.zsh" \
   "$repo_root/scripts/start-trips-tart-runner.zsh" \
   "$repo_root/scripts/trips-linux-lima-runner-controller.zsh" \
   "$repo_root/scripts/trips-tart-runner-controller.zsh" \
   "$repo_root/tests/trips-linux-lima-runner-controller-test.zsh" \
+  "$repo_root/tests/provision-tart-runner-base-test.zsh" \
   "$repo_root/tests/trips-tart-runner-controller-test.zsh"
 "$repo_root/tests/trips-linux-lima-runner-controller-test.zsh"
+"$repo_root/tests/provision-tart-runner-base-test.zsh"
 "$repo_root/tests/trips-tart-runner-controller-test.zsh"
 plist_files=(
   "$repo_root/launchd/com.jai.trips-linux-lima-runner-a.plist"

--- a/tests/provision-tart-runner-base-test.zsh
+++ b/tests/provision-tart-runner-base-test.zsh
@@ -1,0 +1,65 @@
+#!/bin/zsh
+set -eu
+
+repo_root="${0:A:h:h}"
+mkdir -p "${repo_root}/tmp"
+test_directory=$(mktemp -d "${repo_root}/tmp/tart-base-provision-test.XXXXXX")
+trap '/bin/rm -rf -- "$test_directory"' EXIT
+fake_tart="${test_directory}/tart"
+fake_log="${test_directory}/tart.log"
+cat > "$fake_tart" <<'SCRIPT'
+#!/bin/zsh
+set -eu
+print -r -- "$*" >> "$FAKE_TART_LOG"
+if [[ "$1" == list ]]; then
+  [[ "${FAKE_BASE_EXISTS:-false}" == true ]] && print -r -- "${FAKE_BASE_NAME}"
+fi
+SCRIPT
+chmod 700 "$fake_tart"
+
+export TRIPS_TART_BASE_LIBRARY_ONLY=true
+source "${repo_root}/scripts/provision-tart-runner-base.zsh"
+
+base_name_is_safe trips-runner-base-next
+if base_name_is_safe trips-runner-base; then
+  print -u2 -- 'Expected the live base name to be rejected'
+  exit 1
+fi
+if base_name_is_safe trips-runner-base-pre-apfs-expand; then
+  print -u2 -- 'Expected the rollback base name to be rejected'
+  exit 1
+fi
+
+FAKE_TART_LOG="$fake_log" \
+FAKE_BASE_NAME=trips-runner-base-next \
+TRIPS_TART_BASE_VM=trips-runner-base-next \
+TRIPS_TART_CLI="$fake_tart" \
+TRIPS_TART_BASE_LIBRARY_ONLY=false \
+zsh "${repo_root}/scripts/provision-tart-runner-base.zsh"
+[[ "$(sed -n '1p' "$fake_log")" == 'list --source local --quiet' ]]
+[[ "$(sed -n '2p' "$fake_log")" == 'clone ghcr.io/cirruslabs/macos-tahoe-xcode:latest trips-runner-base-next' ]]
+[[ "$(sed -n '3p' "$fake_log")" == 'set trips-runner-base-next --cpu 4 --memory 16384 --disk-size 120' ]]
+
+: > "$fake_log"
+FAKE_TART_LOG="$fake_log" \
+FAKE_BASE_NAME=trips-runner-base-next \
+FAKE_BASE_EXISTS=true \
+TRIPS_TART_BASE_VM=trips-runner-base-next \
+TRIPS_TART_CLI="$fake_tart" \
+TRIPS_TART_BASE_LIBRARY_ONLY=false \
+zsh "${repo_root}/scripts/provision-tart-runner-base.zsh" --verify
+[[ "$(sed -n '1p' "$fake_log")" == 'list --source local --quiet' ]]
+[[ "$(sed -n '2p' "$fake_log")" == exec\ trips-runner-base-next\ /bin/zsh\ -lc\ * ]]
+
+if FAKE_TART_LOG="$fake_log" \
+  FAKE_BASE_NAME=trips-runner-base-next \
+  FAKE_BASE_EXISTS=true \
+  TRIPS_TART_BASE_VM=trips-runner-base-next \
+  TRIPS_TART_CLI="$fake_tart" \
+  TRIPS_TART_BASE_LIBRARY_ONLY=false \
+  zsh "${repo_root}/scripts/provision-tart-runner-base.zsh"; then
+  print -u2 -- 'Expected an existing candidate base to be rejected'
+  exit 1
+fi
+
+print -- 'Tart base provisioning safeguards passed.'


### PR DESCRIPTION
## Summary
- Adds a non-destructive Tart base-candidate provisioner backed by the Cirrus Labs Tahoe Xcode image.
- Refuses live and rollback base names, records phase timestamps, and verifies guest root/toolchain/runtime prerequisites through Tart Guest Agent.

## Related Issue
Closes #133

## Validation
- bash scripts/validate-workflows.sh
- zsh tests/provision-tart-runner-base-test.zsh