### PR TITLE
fix(ci): parallelize Linux runner queue selection

### DIFF
--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -601,32 +601,32 @@ wait_for_guest_package_manager() {
 
 run_one_ephemeral_runner() {
   local repository="$1" suffix vm_name token runner_name runner_pid runner_status
+  local vm_cleanup_required=false
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-linux-runner-${slot}-job-${suffix}"
   runner_name="${runner_name_prefix}-${suffix}"
   runner_pid=""
   runner_status=1
 
-  if ! repository_is_private "$repository"; then
-    log "refusing non-private or unavailable repository ${repository}"
-    release_selection_lock
-    return 1
-  fi
-
-  log "cloning ${base_vm} to ${vm_name} for ${repository}"
-  "$lima_cli" clone "$base_vm" "$vm_name" \
-    --cpus="$cpus" --memory="$memory_gib" --mount-none --start --tty=false || {
-    release_selection_lock
-    cleanup_runner_vm "$repository" "$runner_name" "$vm_name" || true
-    return 1
-  }
-
   cleanup() {
+    [[ "$vm_cleanup_required" == true ]] || return 0
     cleanup_runner_vm "$repository" "$runner_name" "$vm_name"
   }
   trap 'stop_active_timeout; release_selection_lock; cleanup || exit 1; exit 130' INT TERM
 
   {
+    if ! repository_is_private "$repository"; then
+      log "refusing non-private or unavailable repository ${repository}"
+      return 1
+    fi
+
+    # Lima can leave a partially created VM even when clone exits non-zero or
+    # the controller is interrupted, so arm cleanup before invoking clone.
+    vm_cleanup_required=true
+    log "cloning ${base_vm} to ${vm_name} for ${repository}"
+    "$lima_cli" clone "$base_vm" "$vm_name" \
+      --cpus="$cpus" --memory="$memory_gib" --mount-none --start --tty=false || return 1
+
     wait_for_guest_package_manager "$vm_name" || return 1
     "$lima_cli" shell "$vm_name" -- \
       bash -lc 'set -e; test "$(nproc)" = 3; test "$(free -g | awk '\''/^Mem:/{print $2}'\'')" -ge 7; docker info >/dev/null; docker compose version; test -x /opt/actions-runner/bin/Runner.Listener' || return 1

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -616,9 +616,10 @@ run_one_ephemeral_runner() {
   log "cloning ${base_vm} to ${vm_name} for ${repository}"
   "$lima_cli" clone "$base_vm" "$vm_name" \
     --cpus="$cpus" --memory="$memory_gib" --mount-none --start --tty=false || {
-      release_selection_lock
-      return 1
-    }
+    release_selection_lock
+    cleanup_runner_vm "$repository" "$runner_name" "$vm_name" || true
+    return 1
+  }
 
   cleanup() {
     cleanup_runner_vm "$repository" "$runner_name" "$vm_name"

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -249,27 +249,70 @@ selection_lock_path() {
 }
 
 acquire_selection_lock() {
-  local repository="$1" owner lock_path modified_at now
+  local repository="$1" owner lock_path reclaim_lock_path modified_at now
   selection_lock_path "$repository"
   lock_path="$REPLY"
-  while ! /bin/mkdir "$lock_path" 2>/dev/null; do
+  if ! /bin/mkdir "$lock_path" 2>/dev/null; then
     owner="$(/bin/cat "${lock_path}/pid" 2>/dev/null || true)"
-    if [[ "$owner" == <1-> ]] && ! /bin/kill -0 "$owner" 2>/dev/null; then
-      /bin/rm -rf "$lock_path"
-      continue
+    if [[ "$owner" == <1-> ]] && /bin/kill -0 "$owner" 2>/dev/null; then
+      return 1
+    elif [[ "$owner" != <1-> ]]; then
+      modified_at=$("$timeout_python" -c \
+        'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' \
+        "$lock_path" 2>/dev/null || print 0)
+      now=$(/bin/date +%s)
+      (( modified_at > 0 && now - modified_at >= selection_lock_owner_grace_seconds )) || return 1
+    fi
+
+    # Serialize stale-lock recovery separately from the repository reservation.
+    # Without this guard, two slots can both classify the same directory as
+    # stale, and the slower slot can delete the faster slot's newly acquired
+    # reservation between its removal and mkdir.
+    reclaim_lock_path="${lock_path}.reclaim"
+    if ! /bin/mkdir "$reclaim_lock_path" 2>/dev/null; then
+      owner="$(/bin/cat "${reclaim_lock_path}/pid" 2>/dev/null || true)"
+      if [[ "$owner" == <1-> ]] && ! /bin/kill -0 "$owner" 2>/dev/null; then
+        /bin/rm -rf "$reclaim_lock_path"
+      elif [[ "$owner" != <1-> ]]; then
+        modified_at=$("$timeout_python" -c \
+          'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' \
+          "$reclaim_lock_path" 2>/dev/null || print 0)
+        now=$(/bin/date +%s)
+        if (( modified_at > 0 && now - modified_at >= selection_lock_owner_grace_seconds )); then
+          /bin/rm -rf "$reclaim_lock_path"
+        fi
+      fi
+      return 1
+    fi
+    printf '%s\n' "$$" > "${reclaim_lock_path}/pid" || {
+      /bin/rm -rf "$reclaim_lock_path"
+      return 1
+    }
+
+    # Re-check after winning the recovery guard: another process may have
+    # replaced the stale reservation before this process acquired the guard.
+    owner="$(/bin/cat "${lock_path}/pid" 2>/dev/null || true)"
+    if [[ "$owner" == <1-> ]] && /bin/kill -0 "$owner" 2>/dev/null; then
+      /bin/rm -rf "$reclaim_lock_path"
+      return 1
     fi
     if [[ "$owner" != <1-> ]]; then
       modified_at=$("$timeout_python" -c \
         'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' \
         "$lock_path" 2>/dev/null || print 0)
       now=$(/bin/date +%s)
-      if (( modified_at > 0 && now - modified_at >= selection_lock_owner_grace_seconds )); then
-        /bin/rm -rf "$lock_path"
-        continue
+      if (( modified_at <= 0 || now - modified_at < selection_lock_owner_grace_seconds )); then
+        /bin/rm -rf "$reclaim_lock_path"
+        return 1
       fi
     fi
-    return 1
-  done
+    /bin/rm -rf "$lock_path"
+    if ! /bin/mkdir "$lock_path" 2>/dev/null; then
+      /bin/rm -rf "$reclaim_lock_path"
+      return 1
+    fi
+    /bin/rm -rf "$reclaim_lock_path"
+  fi
   printf '%s\n' "$$" > "${lock_path}/pid" || {
     /bin/rm -rf "$lock_path"
     return 1

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -29,6 +29,7 @@ readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-120}"
 readonly scan_failure_backoff_seconds="${TRIPS_LINUX_LIMA_SCAN_FAILURE_BACKOFF_SECONDS:-60}"
 readonly selection_lock_owner_grace_seconds="${TRIPS_LINUX_LIMA_SELECTION_LOCK_OWNER_GRACE_SECONDS:-10}"
+readonly clone_timeout_seconds="${TRIPS_LINUX_LIMA_CLONE_TIMEOUT_SECONDS:-300}"
 readonly package_manager_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS:-300}"
 readonly package_manager_poll_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS:-2}"
 readonly package_manager_probe_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS:-15}"
@@ -624,7 +625,7 @@ run_one_ephemeral_runner() {
     # the controller is interrupted, so arm cleanup before invoking clone.
     vm_cleanup_required=true
     log "cloning ${base_vm} to ${vm_name} for ${repository}"
-    "$lima_cli" clone "$base_vm" "$vm_name" \
+    run_with_timeout "$clone_timeout_seconds" "$lima_cli" clone "$base_vm" "$vm_name" \
       --cpus="$cpus" --memory="$memory_gib" --mount-none --start --tty=false || return 1
 
     wait_for_guest_package_manager "$vm_name" || return 1

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -27,6 +27,7 @@ readonly timeout_preexec_release_file="${TRIPS_LINUX_LIMA_TIMEOUT_PREEXEC_RELEAS
 readonly claim_timeout_seconds="${TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-120}"
+readonly selection_contention_backoff_seconds="${TRIPS_LINUX_LIMA_SELECTION_CONTENTION_BACKOFF_SECONDS:-15}"
 readonly scan_failure_backoff_seconds="${TRIPS_LINUX_LIMA_SCAN_FAILURE_BACKOFF_SECONDS:-60}"
 readonly selection_lock_owner_grace_seconds="${TRIPS_LINUX_LIMA_SELECTION_LOCK_OWNER_GRACE_SECONDS:-10}"
 readonly clone_timeout_seconds="${TRIPS_LINUX_LIMA_CLONE_TIMEOUT_SECONDS:-300}"
@@ -201,6 +202,7 @@ next_repository() {
   local repository queued_at
   local -i repository_count offset repository_index
   local -i lookup_status
+  local reservation_contended=false
   selected_repository=""
   repository_count=${#repository_list[@]}
   (( repository_count > 0 )) || return 1
@@ -215,12 +217,16 @@ next_repository() {
       (( lookup_status == 1 )) && continue
       return "$lookup_status"
     fi
-    acquire_selection_lock "$repository" || continue
+    if ! acquire_selection_lock "$repository"; then
+      reservation_contended=true
+      continue
+    fi
     selected_repository="$repository"
     repository_scan_start_index=$((repository_index % repository_count + 1))
     log "reserved ${repository} queue (eligible job queued ${queued_at})"
     return 0
   done
+  [[ "$reservation_contended" == true ]] && return 3
   return 1
 }
 
@@ -341,6 +347,9 @@ handle_no_selected_repository() {
   # an idle or failed scan never blocks the other slot from scanning.
   if (( scan_status == 1 )); then
     selection_sleep "$idle_scan_interval_seconds"
+  elif (( scan_status == 3 )); then
+    log "queued work is reserved by another slot; retrying in ${selection_contention_backoff_seconds} seconds"
+    selection_sleep "$selection_contention_backoff_seconds"
   else
     log "GitHub queue scan failed; retrying in ${scan_failure_backoff_seconds} seconds"
     selection_sleep "$scan_failure_backoff_seconds"

--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -16,7 +16,7 @@ readonly runner_name_prefix="${TRIPS_LINUX_LIMA_RUNNER_NAME_PREFIX:-borg-cube-03
 readonly runner_labels="jai-ci,jai-ci-tonegate"
 readonly private_key="/Users/jai/.config/trips-tart-runner/github-app-private-key.pem"
 readonly log_directory="/Users/jai/Library/Logs/trips-linux-lima-runner"
-readonly selection_lock="${LIMA_HOME:-/Users/jai/.lima}/.trips-linux-runner-selection-lock"
+readonly selection_lock_prefix="${LIMA_HOME:-/Users/jai/.lima}/.trips-linux-runner-selection-lock"
 readonly gh_cli="${TRIPS_LINUX_LIMA_GH_CLI:-/opt/homebrew/bin/gh}"
 readonly curl_cli="${TRIPS_LINUX_LIMA_CURL_CLI:-/usr/bin/curl}"
 readonly lima_cli="${TRIPS_LINUX_LIMA_CLI:-/opt/homebrew/bin/limactl}"
@@ -28,6 +28,7 @@ readonly claim_timeout_seconds="${TRIPS_LINUX_LIMA_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS:-2}"
 readonly idle_scan_interval_seconds="${TRIPS_LINUX_LIMA_IDLE_SCAN_INTERVAL_SECONDS:-120}"
 readonly scan_failure_backoff_seconds="${TRIPS_LINUX_LIMA_SCAN_FAILURE_BACKOFF_SECONDS:-60}"
+readonly selection_lock_owner_grace_seconds="${TRIPS_LINUX_LIMA_SELECTION_LOCK_OWNER_GRACE_SECONDS:-10}"
 readonly package_manager_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS:-300}"
 readonly package_manager_poll_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS:-2}"
 readonly package_manager_probe_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS:-15}"
@@ -35,7 +36,10 @@ readonly package_manager_probe_timeout_seconds="${TRIPS_LINUX_LIMA_PACKAGE_MANAG
 typeset -g installation_token_value=""
 typeset -g installation_token_expires_at=0
 typeset -g selected_repository=""
+typeset -g selected_repository_lock=""
 typeset -g active_timeout_pid=""
+typeset -gi repository_scan_start_index=1
+[[ "$slot" == b ]] && repository_scan_start_index=2
 
 export LIMA_HOME="${LIMA_HOME:-/Users/jai/.lima}"
 
@@ -149,15 +153,13 @@ delete_runner_registration() {
 }
 
 repository_workflow_runs() {
-  local repository="$1" run_status
-  for run_status in queued in_progress; do
-    "$gh_cli" api \
-      -H 'Accept: application/vnd.github+json' \
-      -H 'X-GitHub-Api-Version: 2022-11-28' \
-      --paginate \
-      "repos/${repository}/actions/runs?status=${run_status}&per_page=100" \
-      --jq '.workflow_runs[] | [.id, .created_at, .head_repository.full_name] | @tsv' || return 2
-  done
+  local repository="$1" run_status="$2"
+  "$gh_cli" api \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    --paginate \
+    "repos/${repository}/actions/runs?status=${run_status}&per_page=100" \
+    --jq '.workflow_runs[] | [.id, .created_at, .head_repository.full_name] | @tsv' || return 2
 }
 
 workflow_run_oldest_queued_job_timestamp() {
@@ -176,28 +178,35 @@ print(min(matches) if matches else "")' || return 2
 }
 
 repository_oldest_queued_job_timestamp() {
-  local repository="$1" runs run_id run_created_at head_repository queued_at oldest_queued_at
-  oldest_queued_at=""
-  runs=$(repository_workflow_runs "$repository") || return 2
-  while IFS=$'\t' read -r run_id run_created_at head_repository; do
-    [[ -n "$run_id" ]] || continue
-    [[ "$head_repository" == "$repository" ]] || continue
-    queued_at=$(workflow_run_oldest_queued_job_timestamp "$repository" "$run_id") || return 2
-    [[ -n "$queued_at" ]] || continue
-    if [[ -z "$oldest_queued_at" || "$queued_at" < "$oldest_queued_at" ]]; then
-      oldest_queued_at="$queued_at"
-    fi
-  done <<< "$runs"
-  [[ -n "$oldest_queued_at" ]] || return 1
-  print -r -- "$oldest_queued_at"
+  local repository="$1" run_status runs run_id run_created_at head_repository queued_at
+  # GitHub returns each status bucket newest-first. Stop at the first eligible
+  # Linux job: selection only needs proof of work, and walking every job in
+  # every active workflow delayed runner registration by several minutes.
+  for run_status in queued in_progress; do
+    runs=$(repository_workflow_runs "$repository" "$run_status") || return 2
+    while IFS=$'\t' read -r run_id run_created_at head_repository; do
+      [[ -n "$run_id" ]] || continue
+      [[ "$head_repository" == "$repository" ]] || continue
+      queued_at=$(workflow_run_oldest_queued_job_timestamp "$repository" "$run_id") || return 2
+      [[ -n "$queued_at" ]] || continue
+      print -r -- "$queued_at"
+      return 0
+    done <<< "$runs"
+  done
+  return 1
 }
 
 next_repository() {
-  local repository queued_at oldest_queued_at
+  local repository queued_at
+  local -i repository_count offset repository_index
   local -i lookup_status
   selected_repository=""
-  oldest_queued_at=""
-  for repository in "${repository_list[@]}"; do
+  repository_count=${#repository_list[@]}
+  (( repository_count > 0 )) || return 1
+  (( repository_scan_start_index > repository_count )) && repository_scan_start_index=1
+  for (( offset = 0; offset < repository_count; offset++ )); do
+    repository_index=$(((repository_scan_start_index + offset - 1) % repository_count + 1))
+    repository="${repository_list[$repository_index]}"
     if queued_at=$(repository_oldest_queued_job_timestamp "$repository"); then
       :
     else
@@ -205,12 +214,13 @@ next_repository() {
       (( lookup_status == 1 )) && continue
       return "$lookup_status"
     fi
-    if [[ -z "$oldest_queued_at" || "$queued_at" < "$oldest_queued_at" ]]; then
-      selected_repository="$repository"
-      oldest_queued_at="$queued_at"
-    fi
+    acquire_selection_lock "$repository" || continue
+    selected_repository="$repository"
+    repository_scan_start_index=$((repository_index % repository_count + 1))
+    log "reserved ${repository} queue (eligible job queued ${queued_at})"
+    return 0
   done
-  [[ -n "$selected_repository" ]]
+  return 1
 }
 
 wait_for_runner_claim() {
@@ -233,25 +243,48 @@ wait_for_runner_claim() {
   return 1
 }
 
+selection_lock_path() {
+  local repository="$1"
+  REPLY="${selection_lock_prefix}-${repository//\//-}"
+}
+
 acquire_selection_lock() {
-  local owner
-  while ! /bin/mkdir "$selection_lock" 2>/dev/null; do
-    owner="$(/bin/cat "${selection_lock}/pid" 2>/dev/null || true)"
+  local repository="$1" owner lock_path modified_at now
+  selection_lock_path "$repository"
+  lock_path="$REPLY"
+  while ! /bin/mkdir "$lock_path" 2>/dev/null; do
+    owner="$(/bin/cat "${lock_path}/pid" 2>/dev/null || true)"
     if [[ "$owner" == <1-> ]] && ! /bin/kill -0 "$owner" 2>/dev/null; then
-      /bin/rm -rf "$selection_lock"
+      /bin/rm -rf "$lock_path"
       continue
     fi
-    /bin/sleep 2
+    if [[ "$owner" != <1-> ]]; then
+      modified_at=$("$timeout_python" -c \
+        'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' \
+        "$lock_path" 2>/dev/null || print 0)
+      now=$(/bin/date +%s)
+      if (( modified_at > 0 && now - modified_at >= selection_lock_owner_grace_seconds )); then
+        /bin/rm -rf "$lock_path"
+        continue
+      fi
+    fi
+    return 1
   done
-  printf '%s\n' "$$" > "${selection_lock}/pid"
+  printf '%s\n' "$$" > "${lock_path}/pid" || {
+    /bin/rm -rf "$lock_path"
+    return 1
+  }
+  selected_repository_lock="$lock_path"
 }
 
 release_selection_lock() {
   local owner
-  owner="$(/bin/cat "${selection_lock}/pid" 2>/dev/null || true)"
+  [[ -n "$selected_repository_lock" ]] || return 0
+  owner="$(/bin/cat "${selected_repository_lock}/pid" 2>/dev/null || true)"
   if [[ "$owner" == "$$" ]]; then
-    /bin/rm -rf "$selection_lock"
+    /bin/rm -rf "$selected_repository_lock"
   fi
+  selected_repository_lock=""
 }
 
 selection_sleep() {
@@ -260,15 +293,11 @@ selection_sleep() {
 
 handle_no_selected_repository() {
   local -i scan_status="$1"
-  # Keep the shared lock while idle so the second slot cannot duplicate the
-  # repository scan and exhaust the authenticated GitHub API quota. A failed
-  # scan is different: release the lock before backoff so one throttled lane
-  # cannot prevent the other lane from making progress.
+  # Repository reservations are acquired only after a queued job is found, so
+  # an idle or failed scan never blocks the other slot from scanning.
   if (( scan_status == 1 )); then
     selection_sleep "$idle_scan_interval_seconds"
-    release_selection_lock
   else
-    release_selection_lock
     log "GitHub queue scan failed; retrying in ${scan_failure_backoff_seconds} seconds"
     selection_sleep "$scan_failure_backoff_seconds"
   fi
@@ -537,12 +566,16 @@ run_one_ephemeral_runner() {
 
   if ! repository_is_private "$repository"; then
     log "refusing non-private or unavailable repository ${repository}"
+    release_selection_lock
     return 1
   fi
 
   log "cloning ${base_vm} to ${vm_name} for ${repository}"
   "$lima_cli" clone "$base_vm" "$vm_name" \
-    --cpus="$cpus" --memory="$memory_gib" --mount-none --start --tty=false || return 1
+    --cpus="$cpus" --memory="$memory_gib" --mount-none --start --tty=false || {
+      release_selection_lock
+      return 1
+    }
 
   cleanup() {
     cleanup_runner_vm "$repository" "$runner_name" "$vm_name"
@@ -613,7 +646,6 @@ main() {
   done <<< "$stale_vms"
 
   while true; do
-    acquire_selection_lock
     if next_repository; then
       repository="$selected_repository"
       if run_one_ephemeral_runner "$repository"; then

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -11,6 +11,7 @@ cat > "$fake_gh" <<'SCRIPT'
 #!/bin/zsh
 set -eu
 request="$*"
+[[ -n "${FAKE_GH_REQUEST_LOG:-}" ]] && print -r -- "$request" >> "$FAKE_GH_REQUEST_LOG"
 if [[ "$request" == *'/actions/runs?'* ]]; then
   print -r -- $'101\t2026-08-25T00:00:00Z\tjai/tonegate'
 elif [[ "$request" == *'/actions/runs/101/jobs?'* ]]; then
@@ -80,6 +81,9 @@ fi
 if [[ "$1" == list ]]; then
   exit 0
 fi
+if [[ "$1" == clone && "${FAKE_CLONE_FAILURE:-false}" == true ]]; then
+  exit 42
+fi
 exit 0
 SCRIPT
 chmod 700 "$fake_lima"
@@ -96,6 +100,7 @@ export TRIPS_LINUX_LIMA_CLAIM_POLL_SECONDS=0.1
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_TIMEOUT_SECONDS=10
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_POLL_SECONDS=4
 export TRIPS_LINUX_LIMA_PACKAGE_MANAGER_PROBE_TIMEOUT_SECONDS=1
+export TRIPS_LINUX_LIMA_SELECTION_LOCK_OWNER_GRACE_SECONDS=1
 source "${repo_root}/scripts/trips-linux-lima-runner-controller.zsh"
 mkdir -p "$LIMA_HOME"
 installation_token_value=test-token
@@ -125,6 +130,17 @@ if workflow_run_oldest_queued_job_timestamp jai/tonegate 101 | /usr/bin/grep -q 
   exit 1
 fi
 
+export FAKE_GH_REQUEST_LOG="${test_directory}/gh-requests.log"
+export FAKE_SCENARIO=standard
+: > "$FAKE_GH_REQUEST_LOG"
+assert_equal 2026-08-25T00:00:01Z "$(repository_oldest_queued_job_timestamp jai/tonegate)"
+assert_equal 1 "$(/usr/bin/grep -c '/actions/runs?' "$FAKE_GH_REQUEST_LOG")"
+if /usr/bin/grep -q 'status=in_progress' "$FAKE_GH_REQUEST_LOG"; then
+  print -u2 -- 'Expected queue discovery to stop before scanning in-progress runs'
+  exit 1
+fi
+unset FAKE_GH_REQUEST_LOG
+
 if [[ ",${repositories}," == *',jai/trips-ci,'* ]]; then
   print -u2 -- 'Expected the public trips-ci repository to stay off private self-hosted runners'
   exit 1
@@ -146,16 +162,94 @@ repository_oldest_queued_job_timestamp() {
   print -r -- "$queued_at"
 }
 next_repository
+assert_equal jai/tonegate "$selected_repository"
+release_selection_lock
+repository_scan_start_index=2
+next_repository
 assert_equal jai/trips-api "$selected_repository"
+release_selection_lock
+repository_scan_start_index=1
+tonegate_queued_at=""
+next_repository
+assert_equal jai/trips-api "$selected_repository"
+release_selection_lock
 api_queued_at=""
 next_repository
 assert_equal jai/trips-frontend "$selected_repository"
-tonegate_queued_at=""
+release_selection_lock
 frontend_queued_at=""
 if next_repository; then
   print -u2 -- 'Expected no queued Linux repository'
   exit 1
 fi
+
+tonegate_queued_at=2026-08-25T00:03:00Z
+api_queued_at=2026-08-25T00:01:00Z
+frontend_queued_at=2026-08-25T00:02:00Z
+repository_scan_start_index=1
+selection_lock_path jai/tonegate
+reserved_tonegate_lock="$REPLY"
+mkdir "$reserved_tonegate_lock"
+print -r -- $$ > "${reserved_tonegate_lock}/pid"
+next_repository
+assert_equal jai/trips-api "$selected_repository"
+release_selection_lock
+rm -rf "$reserved_tonegate_lock"
+
+selection_lock_path jai/tonegate
+stale_tonegate_lock="$REPLY"
+mkdir "$stale_tonegate_lock"
+print -r -- 999999 > "${stale_tonegate_lock}/pid"
+repository_scan_start_index=1
+next_repository
+assert_equal jai/tonegate "$selected_repository"
+assert_equal "$stale_tonegate_lock" "$selected_repository_lock"
+release_selection_lock
+
+selection_lock_path jai/tonegate
+ownerless_tonegate_lock="$REPLY"
+mkdir "$ownerless_tonegate_lock"
+/usr/bin/touch -t 200001010000 "$ownerless_tonegate_lock"
+acquire_selection_lock jai/tonegate
+assert_equal "$ownerless_tonegate_lock" "$selected_repository_lock"
+release_selection_lock
+
+acquire_selection_lock jai/tonegate
+typeset production_repository_is_private="${functions[repository_is_private]}"
+repository_is_private() { return 0; }
+export FAKE_CLONE_FAILURE=true
+if run_one_ephemeral_runner jai/tonegate; then
+  print -u2 -- 'Expected a clone failure to fail the runner cycle'
+  exit 1
+fi
+unset FAKE_CLONE_FAILURE
+functions[repository_is_private]="$production_repository_is_private"
+if [[ -n "$selected_repository_lock" || -d "$ownerless_tonegate_lock" ]]; then
+  print -u2 -- 'Expected a clone failure to release its repository reservation'
+  exit 1
+fi
+
+concurrent_lock_home="${test_directory}/concurrent-locks"
+concurrent_selection_output="${test_directory}/concurrent-selections"
+mkdir "$concurrent_lock_home"
+for concurrent_slot in a b; do
+  env \
+    TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true \
+    TRIPS_LINUX_LIMA_SLOT="$concurrent_slot" \
+    LIMA_HOME="$concurrent_lock_home" \
+    TRIPS_LINUX_LIMA_REPOSITORIES='jai/tonegate,jai/trips-api,jai/trips-frontend' \
+    /bin/zsh -c '
+      source "$1"
+      repository_oldest_queued_job_timestamp() { print -r -- 2026-08-25T00:00:00Z; }
+      next_repository
+      print -r -- "slot=${slot} selected=${selected_repository}" >> "$2"
+      /bin/sleep 0.2
+      release_selection_lock
+    ' zsh "${repo_root}/scripts/trips-linux-lima-runner-controller.zsh" "$concurrent_selection_output" &
+done
+wait
+assert_equal $'slot=a selected=jai/tonegate\nslot=b selected=jai/trips-api' \
+  "$(LC_ALL=C /usr/bin/sort "$concurrent_selection_output")"
 
 repository_oldest_queued_job_timestamp() { return 2; }
 if next_repository; then
@@ -171,34 +265,24 @@ typeset -ga observed_selection_lock_states=()
 typeset -ga observed_selection_sleep_durations=()
 selection_sleep() {
   observed_selection_sleep_durations+=("$1")
-  if [[ -d "$selection_lock" ]]; then
+  if [[ -n "$selected_repository_lock" && -d "$selected_repository_lock" ]]; then
     observed_selection_lock_states+=(locked)
   else
     observed_selection_lock_states+=(unlocked)
   fi
 }
 
-acquire_selection_lock
 observed_selection_lock_states=()
 observed_selection_sleep_durations=()
 handle_no_selected_repository 1
-assert_equal locked "${observed_selection_lock_states[1]}"
+assert_equal unlocked "${observed_selection_lock_states[1]}"
 assert_equal 120 "${observed_selection_sleep_durations[1]}"
-if [[ -d "$selection_lock" ]]; then
-  print -u2 -- 'Expected an empty healthy scan to release the selection lock after idle sleep'
-  exit 1
-fi
 
-acquire_selection_lock
 observed_selection_lock_states=()
 observed_selection_sleep_durations=()
 handle_no_selected_repository 2
 assert_equal unlocked "${observed_selection_lock_states[1]}"
 assert_equal 60 "${observed_selection_sleep_durations[1]}"
-if [[ -d "$selection_lock" ]]; then
-  print -u2 -- 'Expected a failed queue scan to release the selection lock before backoff'
-  exit 1
-fi
 functions[selection_sleep]="$production_selection_sleep"
 
 runner_lookup 'jai/tonegate' 'page-two-runner'

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -279,6 +279,56 @@ assert_equal jai/tonegate "${clone_failure_cleanup[1]}"
   exit 1
 }
 
+clone_signal_home="${test_directory}/clone-signal-home"
+clone_signal_started="${test_directory}/clone-signal-started"
+clone_signal_cleanup="${test_directory}/clone-signal-cleanup"
+clone_signal_runner="${test_directory}/clone-signal-runner"
+cat > "$clone_signal_runner" <<SCRIPT
+#!/bin/zsh
+set -u
+export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
+export TRIPS_LINUX_LIMA_SLOT=a
+export LIMA_HOME='${clone_signal_home}'
+export TRIPS_LINUX_LIMA_CLI=fake_lima
+source '${repo_root}/scripts/trips-linux-lima-runner-controller.zsh'
+mkdir -p "\$LIMA_HOME"
+repository_is_private() { return 0; }
+fake_lima() {
+  if [[ "\$1" == clone ]]; then
+    print -r -- started > '${clone_signal_started}'
+    while true; do /bin/sleep 0.05; done
+  fi
+  return 0
+}
+cleanup_runner_vm() { print -r -- cleaned > '${clone_signal_cleanup}'; }
+acquire_selection_lock jai/tonegate
+run_one_ephemeral_runner jai/tonegate
+SCRIPT
+chmod 700 "$clone_signal_runner"
+"$clone_signal_runner" &
+clone_signal_pid=$!
+for _ in {1..200}; do
+  [[ -e "$clone_signal_started" ]] && break
+  /bin/sleep 0.01
+done
+if [[ ! -e "$clone_signal_started" ]]; then
+  print -u2 -- 'Expected the clone signal test to enter Lima clone'
+  exit 1
+fi
+/bin/kill -TERM "$clone_signal_pid"
+clone_signal_status=0
+wait "$clone_signal_pid" 2>/dev/null || clone_signal_status=$?
+assert_equal 130 "$clone_signal_status"
+if [[ ! -e "$clone_signal_cleanup" ]]; then
+  print -u2 -- 'Expected SIGTERM during clone to clean the partial VM'
+  exit 1
+fi
+selection_lock_path jai/tonegate
+if [[ -d "${clone_signal_home}/${REPLY:t}" ]]; then
+  print -u2 -- 'Expected SIGTERM during clone to release the repository reservation'
+  exit 1
+fi
+
 concurrent_lock_home="${test_directory}/concurrent-locks"
 concurrent_selection_output="${test_directory}/concurrent-selections"
 mkdir "$concurrent_lock_home"

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -214,6 +214,43 @@ acquire_selection_lock jai/tonegate
 assert_equal "$ownerless_tonegate_lock" "$selected_repository_lock"
 release_selection_lock
 
+stale_contention_home="${test_directory}/stale-contention-locks"
+stale_contention_lock="${stale_contention_home}/.trips-linux-runner-selection-lock-jai-tonegate"
+stale_contention_start="${test_directory}/stale-contention-start"
+stale_contention_ready="${test_directory}/stale-contention-ready"
+stale_contention_winners="${test_directory}/stale-contention-winners"
+mkdir -p "$stale_contention_lock" "$stale_contention_ready"
+print -r -- 999999 > "${stale_contention_lock}/pid"
+: > "$stale_contention_winners"
+for contender in {1..12}; do
+  env \
+    TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true \
+    TRIPS_LINUX_LIMA_SLOT=a \
+    LIMA_HOME="$stale_contention_home" \
+    /bin/zsh -c '
+      source "$1"
+      : > "$2/$3"
+      while [[ ! -e "$4" ]]; do /bin/sleep 0.001; done
+      if acquire_selection_lock jai/tonegate; then
+        print -r -- "$$" >> "$5"
+        /bin/sleep 0.2
+        release_selection_lock
+      fi
+    ' zsh "${repo_root}/scripts/trips-linux-lima-runner-controller.zsh" \
+      "$stale_contention_ready" "$contender" "$stale_contention_start" \
+      "$stale_contention_winners" &
+done
+while (( $(find "$stale_contention_ready" -type f | wc -l | tr -d ' ') < 12 )); do
+  /bin/sleep 0.002
+done
+: > "$stale_contention_start"
+wait
+assert_equal 1 "$(wc -l < "$stale_contention_winners" | tr -d ' ')"
+if find "$stale_contention_home" -maxdepth 1 -name '*.reclaim' | /usr/bin/grep -q .; then
+  print -u2 -- 'Expected stale-lock recovery guards to be cleaned up'
+  exit 1
+fi
+
 acquire_selection_lock jai/tonegate
 typeset production_repository_is_private="${functions[repository_is_private]}"
 repository_is_private() { return 0; }

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -196,6 +196,20 @@ assert_equal jai/trips-api "$selected_repository"
 release_selection_lock
 rm -rf "$reserved_tonegate_lock"
 
+api_queued_at=""
+frontend_queued_at=""
+mkdir "$reserved_tonegate_lock"
+print -r -- $$ > "${reserved_tonegate_lock}/pid"
+if next_repository; then
+  print -u2 -- 'Expected reservation contention to defer selection'
+  exit 1
+else
+  assert_equal 3 "$?"
+fi
+rm -rf "$reserved_tonegate_lock"
+api_queued_at=2026-08-25T00:01:00Z
+frontend_queued_at=2026-08-25T00:02:00Z
+
 selection_lock_path jai/tonegate
 stale_tonegate_lock="$REPLY"
 mkdir "$stale_tonegate_lock"
@@ -387,6 +401,12 @@ observed_selection_sleep_durations=()
 handle_no_selected_repository 1
 assert_equal unlocked "${observed_selection_lock_states[1]}"
 assert_equal 120 "${observed_selection_sleep_durations[1]}"
+
+observed_selection_lock_states=()
+observed_selection_sleep_durations=()
+handle_no_selected_repository 3
+assert_equal unlocked "${observed_selection_lock_states[1]}"
+assert_equal 15 "${observed_selection_sleep_durations[1]}"
 
 observed_selection_lock_states=()
 observed_selection_sleep_durations=()

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -253,7 +253,10 @@ fi
 
 acquire_selection_lock jai/tonegate
 typeset production_repository_is_private="${functions[repository_is_private]}"
+typeset production_cleanup_runner_vm="${functions[cleanup_runner_vm]}"
+typeset -ga clone_failure_cleanup=()
 repository_is_private() { return 0; }
+cleanup_runner_vm() { clone_failure_cleanup=("$1" "$2" "$3"); }
 export FAKE_CLONE_FAILURE=true
 if run_one_ephemeral_runner jai/tonegate; then
   print -u2 -- 'Expected a clone failure to fail the runner cycle'
@@ -261,10 +264,20 @@ if run_one_ephemeral_runner jai/tonegate; then
 fi
 unset FAKE_CLONE_FAILURE
 functions[repository_is_private]="$production_repository_is_private"
+functions[cleanup_runner_vm]="$production_cleanup_runner_vm"
 if [[ -n "$selected_repository_lock" || -d "$ownerless_tonegate_lock" ]]; then
   print -u2 -- 'Expected a clone failure to release its repository reservation'
   exit 1
 fi
+assert_equal jai/tonegate "${clone_failure_cleanup[1]}"
+[[ "${clone_failure_cleanup[2]}" == borg-cube-03-lima-a-* ]] || {
+  print -u2 -- 'Expected clone failure cleanup to receive the runner name'
+  exit 1
+}
+[[ "${clone_failure_cleanup[3]}" == trips-linux-runner-a-job-* ]] || {
+  print -u2 -- 'Expected clone failure cleanup to receive the partially created VM name'
+  exit 1
+}
 
 concurrent_lock_home="${test_directory}/concurrent-locks"
 concurrent_selection_output="${test_directory}/concurrent-selections"

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -283,23 +283,27 @@ clone_signal_home="${test_directory}/clone-signal-home"
 clone_signal_started="${test_directory}/clone-signal-started"
 clone_signal_cleanup="${test_directory}/clone-signal-cleanup"
 clone_signal_runner="${test_directory}/clone-signal-runner"
+clone_signal_lima="${test_directory}/clone-signal-lima"
+cat > "$clone_signal_lima" <<'SCRIPT'
+#!/bin/zsh
+set -eu
+if [[ "$1" == clone ]]; then
+  print -r -- started > "${FAKE_CLONE_SIGNAL_STARTED:?}"
+  /bin/sleep 5
+fi
+SCRIPT
+chmod 700 "$clone_signal_lima"
 cat > "$clone_signal_runner" <<SCRIPT
 #!/bin/zsh
 set -u
 export TRIPS_LINUX_RUNNER_CONTROLLER_LIBRARY_ONLY=true
 export TRIPS_LINUX_LIMA_SLOT=a
 export LIMA_HOME='${clone_signal_home}'
-export TRIPS_LINUX_LIMA_CLI=fake_lima
+export TRIPS_LINUX_LIMA_CLI='${clone_signal_lima}'
+export FAKE_CLONE_SIGNAL_STARTED='${clone_signal_started}'
 source '${repo_root}/scripts/trips-linux-lima-runner-controller.zsh'
 mkdir -p "\$LIMA_HOME"
 repository_is_private() { return 0; }
-fake_lima() {
-  if [[ "\$1" == clone ]]; then
-    print -r -- started > '${clone_signal_started}'
-    while true; do /bin/sleep 0.05; done
-  fi
-  return 0
-}
 cleanup_runner_vm() { print -r -- cleaned > '${clone_signal_cleanup}'; }
 acquire_selection_lock jai/tonegate
 run_one_ephemeral_runner jai/tonegate
@@ -315,10 +319,16 @@ if [[ ! -e "$clone_signal_started" ]]; then
   print -u2 -- 'Expected the clone signal test to enter Lima clone'
   exit 1
 fi
+clone_signal_started_at=$(/bin/date +%s)
 /bin/kill -TERM "$clone_signal_pid"
 clone_signal_status=0
 wait "$clone_signal_pid" 2>/dev/null || clone_signal_status=$?
+clone_signal_elapsed=$(( $(/bin/date +%s) - clone_signal_started_at ))
 assert_equal 130 "$clone_signal_status"
+if (( clone_signal_elapsed > 2 )); then
+  print -u2 -- "Expected SIGTERM during external clone to finish promptly; took ${clone_signal_elapsed}s"
+  exit 1
+fi
 if [[ ! -e "$clone_signal_cleanup" ]]; then
   print -u2 -- 'Expected SIGTERM during clone to clean the partial VM'
   exit 1


### PR DESCRIPTION
## Summary

- replace the global Linux selector lock with per-repository reservations so two Lima slots can provision independent work concurrently
- stagger and rotate slot scans, and stop on the first eligible queued job/status instead of enumerating the full cross-repository queue
- recover stale and ownerless reservations and release them on early private-repository and clone failures
- add deterministic two-process concurrency, queue short-circuit, stale-lock, ownerless-lock, and early-failure coverage

## Related Issue

Fixes #134

## Validation

- `tests/trips-linux-lima-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`
- independent exact-head `gpt-5.6-sol` xhigh review with Fast Mode disabled