### PR TITLE
fix(ci): attach iOS runner work disks reliably

### DIFF
--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -403,7 +403,7 @@ start_tart_vm() {
       ;;
   esac
   "$tart_cli" run --no-graphics --no-audio --no-clipboard \
-    "${network_arguments[@]}" --disk="${work_disk}:sync=none" "$vm_name" >"$vm_log" 2>&1 &
+    "${network_arguments[@]}" --disk="$work_disk" "$vm_name" >"$vm_log" 2>&1 &
   REPLY=$!
 }
 

--- a/tests/trips-tart-runner-controller-test.zsh
+++ b/tests/trips-tart-runner-controller-test.zsh
@@ -462,11 +462,11 @@ assert_configured_network_invocation() {
 }
 
 assert_configured_network_invocation unset default-vm \
-  'run --no-graphics --no-audio --no-clipboard --disk='"${test_directory}/default-vm.raw"':sync=none default-vm'
+  'run --no-graphics --no-audio --no-clipboard --disk='"${test_directory}/default-vm.raw"' default-vm'
 assert_configured_network_invocation shared shared-vm \
-  'run --no-graphics --no-audio --no-clipboard --disk='"${test_directory}/shared-vm.raw"':sync=none shared-vm'
+  'run --no-graphics --no-audio --no-clipboard --disk='"${test_directory}/shared-vm.raw"' shared-vm'
 assert_configured_network_invocation softnet softnet-vm \
-  'run --no-graphics --no-audio --no-clipboard --net-softnet --disk='"${test_directory}/softnet-vm.raw"':sync=none softnet-vm'
+  'run --no-graphics --no-audio --no-clipboard --net-softnet --disk='"${test_directory}/softnet-vm.raw"' softnet-vm'
 
 if start_tart_vm 'invalid-vm' "${test_directory}/invalid.raw" "${test_directory}/invalid.log" unsupported; then
   print -u2 -- 'Expected an unsupported Tart network mode to fail closed'


### PR DESCRIPTION
## Summary
- Attach the disposable iOS RunnerWork disk without Tart `sync=none`, which is invisible to macOS guests on Borg Tart 2.35.
- Retain executable coverage for default, shared, and softnet controller invocations.

## Related Issue
Closes #137

## Validation
- `zsh tests/trips-tart-runner-controller-test.zsh`
- `bash scripts/validate-workflows.sh`
- Borg-03 live probe: a 60 GiB disk without `sync=none` was the sole non-root physical disk and mounted at `/Volumes/RunnerWork` with 60 GiB free.

## Notes
- #137 is labelled `implementation-ready` for the issue-flow gate.