### PR TITLE
fix(ci): require Android external work volume

### DIFF
--- a/scripts/trips-android-host-runner-controller.zsh
+++ b/scripts/trips-android-host-runner-controller.zsh
@@ -62,6 +62,8 @@ work_volume_mounted() {
 prepare_work_root() {
   work_volume_mounted || return 1
   cd "$work_volume" || return 1
+  work_volume_mounted || return 1
+  [[ "$PWD" == "$work_volume" ]] || return 1
   mkdir -p "$work_root_relative" || return 1
   [[ -d "$work_root_relative" && -w "$work_root_relative" ]]
 }

--- a/scripts/trips-android-host-runner-controller.zsh
+++ b/scripts/trips-android-host-runner-controller.zsh
@@ -9,11 +9,13 @@ readonly runner_root="${TRIPS_ANDROID_RUNNER_ROOT:-/Users/jai/.local/share/trips
 readonly work_root="${TRIPS_ANDROID_WORK_ROOT:-/Volumes/RunnerWork/android-host-jobs}"
 readonly sdk_root="${TRIPS_ANDROID_SDK_ROOT:-/Volumes/RunnerWork/android-sdk}"
 readonly avd_root="${TRIPS_ANDROID_AVD_ROOT:-/Volumes/RunnerWork/android-user/avd}"
+readonly work_volume="${TRIPS_ANDROID_WORK_VOLUME:-/Volumes/RunnerWork}"
 readonly lock_path="${TRIPS_ANDROID_NATIVE_LANE_LOCK:-/Users/jai/Library/Logs/trips-tart-native-lane.lock}"
 readonly controller_lock="${TRIPS_ANDROID_CONTROLLER_LOCK:-/Users/jai/Library/Logs/trips-android-host-runner/controller.lock}"
 readonly gh_cli="${TRIPS_ANDROID_GH_CLI:-/opt/homebrew/bin/gh}"
 readonly shlock_cli="${TRIPS_ANDROID_SHLOCK_CLI:-/usr/bin/shlock}"
 readonly pgrep_cli="${TRIPS_ANDROID_PGREP_CLI:-/usr/bin/pgrep}"
+readonly mount_cli="${TRIPS_ANDROID_MOUNT_CLI:-/sbin/mount}"
 readonly minimum_free_gib="${TRIPS_ANDROID_MINIMUM_FREE_GIB:-5}"
 readonly claim_timeout_seconds="${TRIPS_ANDROID_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_ANDROID_CLAIM_POLL_SECONDS:-2}"
@@ -40,6 +42,7 @@ release_native_lane() {
 
 android_preflight() {
   [[ "$(scutil --get ComputerName)" == "$host_label" ]] || return 1
+  work_volume_mounted || return 1
   [[ "$(df -g / | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
   [[ "$(df -g "$work_root" | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
   [[ -x "$runner_root/bin/Runner.Listener" ]] || return 1
@@ -48,6 +51,11 @@ android_preflight() {
   emulator_acceleration_healthy || return 1
   ANDROID_SDK_ROOT="$sdk_root" ANDROID_AVD_HOME="$avd_root" \
     "$sdk_root/emulator/emulator" -list-avds | grep -qx ci-android-arm64
+}
+
+work_volume_mounted() {
+  [[ "$work_root" == "$work_volume"/* ]] || return 1
+  "$mount_cli" | grep -Fq " on ${work_volume} ("
 }
 
 emulator_acceleration_healthy() {
@@ -196,12 +204,13 @@ cleanup_and_release() {
 }
 
 main() {
-  mkdir -p "${controller_lock:h}" "$work_root"
+  mkdir -p "${controller_lock:h}"
   acquire_lock "$controller_lock" || return 1
   trap 'cleanup_and_release' EXIT
   trap 'exit 143' INT TERM
   "$gh_cli" auth status >/dev/null 2>&1 || return 1
   while true; do
+    work_volume_mounted || { log 'Android external work volume is not mounted; refusing runner registration'; sleep 30; continue; }
     queued_android_job_exists || { sleep 30; continue; }
     acquire_lock "$lock_path" || { sleep 15; continue; }
     native_lock_owned=true

--- a/scripts/trips-android-host-runner-controller.zsh
+++ b/scripts/trips-android-host-runner-controller.zsh
@@ -42,7 +42,7 @@ release_native_lane() {
 
 android_preflight() {
   [[ "$(scutil --get ComputerName)" == "$host_label" ]] || return 1
-  work_volume_mounted || return 1
+  prepare_work_root || return 1
   [[ "$(df -g / | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
   [[ "$(df -g "$work_root" | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
   [[ -x "$runner_root/bin/Runner.Listener" ]] || return 1
@@ -56,6 +56,12 @@ android_preflight() {
 work_volume_mounted() {
   [[ "$work_root" == "$work_volume"/* ]] || return 1
   "$mount_cli" | grep -Fq " on ${work_volume} ("
+}
+
+prepare_work_root() {
+  work_volume_mounted || return 1
+  mkdir -p "$work_root" || return 1
+  work_volume_mounted && [[ -d "$work_root" && -w "$work_root" ]]
 }
 
 emulator_acceleration_healthy() {
@@ -151,6 +157,7 @@ cleanup_active_runner() {
 
 run_one_job() {
   local suffix job_root runner_name token runner_pid runner_status claim_status
+  prepare_work_root || return 1
   suffix="$(date -u '+%Y%m%d%H%M%S')-$$"
   job_root="${work_root}/job-${suffix}"
   runner_name="${host_label}-android-${suffix}"

--- a/scripts/trips-android-host-runner-controller.zsh
+++ b/scripts/trips-android-host-runner-controller.zsh
@@ -10,6 +10,7 @@ readonly work_root="${TRIPS_ANDROID_WORK_ROOT:-/Volumes/RunnerWork/android-host-
 readonly sdk_root="${TRIPS_ANDROID_SDK_ROOT:-/Volumes/RunnerWork/android-sdk}"
 readonly avd_root="${TRIPS_ANDROID_AVD_ROOT:-/Volumes/RunnerWork/android-user/avd}"
 readonly work_volume="${TRIPS_ANDROID_WORK_VOLUME:-/Volumes/RunnerWork}"
+readonly work_root_relative="${work_root#${work_volume}/}"
 readonly lock_path="${TRIPS_ANDROID_NATIVE_LANE_LOCK:-/Users/jai/Library/Logs/trips-tart-native-lane.lock}"
 readonly controller_lock="${TRIPS_ANDROID_CONTROLLER_LOCK:-/Users/jai/Library/Logs/trips-android-host-runner/controller.lock}"
 readonly gh_cli="${TRIPS_ANDROID_GH_CLI:-/opt/homebrew/bin/gh}"
@@ -44,7 +45,7 @@ android_preflight() {
   [[ "$(scutil --get ComputerName)" == "$host_label" ]] || return 1
   prepare_work_root || return 1
   [[ "$(df -g / | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
-  [[ "$(df -g "$work_root" | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
+  [[ "$(df -g "$work_root_relative" | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
   [[ -x "$runner_root/bin/Runner.Listener" ]] || return 1
   [[ -x "$sdk_root/emulator/emulator" && -x "$sdk_root/platform-tools/adb" ]] || return 1
   java -version >/dev/null 2>&1 || return 1
@@ -54,14 +55,15 @@ android_preflight() {
 }
 
 work_volume_mounted() {
-  [[ "$work_root" == "$work_volume"/* ]] || return 1
+  [[ "$work_root" == "$work_volume"/* && "$work_root_relative" != "$work_root" ]] || return 1
   "$mount_cli" | grep -Fq " on ${work_volume} ("
 }
 
 prepare_work_root() {
   work_volume_mounted || return 1
-  mkdir -p "$work_root" || return 1
-  work_volume_mounted && [[ -d "$work_root" && -w "$work_root" ]]
+  cd "$work_volume" || return 1
+  mkdir -p "$work_root_relative" || return 1
+  [[ -d "$work_root_relative" && -w "$work_root_relative" ]]
 }
 
 emulator_acceleration_healthy() {
@@ -156,16 +158,17 @@ cleanup_active_runner() {
 }
 
 run_one_job() {
-  local suffix job_root runner_name token runner_pid runner_status claim_status
+  local suffix job_root job_root_absolute runner_name token runner_pid runner_status claim_status
   prepare_work_root || return 1
   suffix="$(date -u '+%Y%m%d%H%M%S')-$$"
-  job_root="${work_root}/job-${suffix}"
+  job_root="${work_root_relative}/job-${suffix}"
   runner_name="${host_label}-android-${suffix}"
   mkdir -p "$job_root/tmp" "$job_root/npm" "$job_root/gradle" "$job_root/work"
   [[ -w "$job_root/tmp" && -w "$job_root/npm" && -w "$job_root/gradle" && -w "$job_root/work" ]] || {
     /bin/rm -rf -- "$job_root"
     return 1
   }
+  job_root_absolute="$(cd "$job_root" && pwd)"
   /bin/cp -R "$runner_root" "$job_root/runner" || {
     /bin/rm -rf -- "$job_root"
     return 1
@@ -177,16 +180,16 @@ run_one_job() {
   print -r -- "$token" | (
     cd "$job_root/runner" || exit 1
     IFS= read -r token
-    export TMPDIR="$job_root/tmp" npm_config_cache="$job_root/npm" GRADLE_USER_HOME="$job_root/gradle"
+    export TMPDIR="$job_root_absolute/tmp" npm_config_cache="$job_root_absolute/npm" GRADLE_USER_HOME="$job_root_absolute/gradle"
     export ANDROID_SDK_ROOT="$sdk_root" ANDROID_HOME="$sdk_root" ANDROID_AVD_HOME="$avd_root" ANDROID_USER_HOME="${avd_root:h}"
-    ./config.sh --unattended --ephemeral --disableupdate --url "https://github.com/${repository}" --token "$token" --name "$runner_name" --labels "${host_label},android" --work "$job_root/work" || exit $?
+    ./config.sh --unattended --ephemeral --disableupdate --url "https://github.com/${repository}" --token "$token" --name "$runner_name" --labels "${host_label},android" --work "$job_root_absolute/work" || exit $?
     ./run.sh
   ) &
   runner_pid=$!
   active_runner_pid="$runner_pid"
   active_runner_name="$runner_name"
   active_job_root="$job_root"
-  if wait_for_runner_claim "$runner_pid" "$job_root"; then
+  if wait_for_runner_claim "$runner_pid" "$job_root_absolute"; then
     if wait "$runner_pid"; then
       runner_status=0
     else

--- a/tests/trips-android-host-runner-controller-test.zsh
+++ b/tests/trips-android-host-runner-controller-test.zsh
@@ -101,6 +101,9 @@ TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true \
 [[ -x "$repo_root/scripts/start-trips-android-host-runner.zsh" ]]
 [[ -x "$repo_root/scripts/trips-android-host-runner-controller.zsh" ]]
 work_volume_mounted
+[[ ! -e "$test_root/work-volume/work" ]]
+prepare_work_root
+[[ -d "$test_root/work-volume/work" && -w "$test_root/work-volume/work" ]]
 if TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true TRIPS_ANDROID_WORK_VOLUME="$test_root/not-mounted" TRIPS_ANDROID_WORK_ROOT="$test_root/not-mounted/work" \
   TRIPS_ANDROID_MOUNT_CLI="$fake_mount" zsh -c 'source "$1"; work_volume_mounted' zsh "$repo_root/scripts/trips-android-host-runner-controller.zsh"; then
   print -u2 -- 'an absent external Android work volume must fail closed'
@@ -152,6 +155,18 @@ if wait_for_runner_claim $$ "$test_root/work/job-unclaimed"; then
 else
   [[ $? -eq 2 ]]
 fi
+
+runner_log="$test_root/mount-loss-runner.log"
+gh_log="$test_root/mount-loss-gh.log"
+: >"$runner_log"
+: >"$gh_log"
+work_volume_mounted() { return 1; }
+if FAKE_GH_SCENARIO=runner FAKE_RUNNER_LOG="$runner_log" FAKE_GH_LOG="$gh_log" run_one_job; then
+  print -u2 -- 'runner creation must fail closed when the external work volume is lost'
+  exit 1
+fi
+[[ ! -s "$runner_log" && ! -s "$gh_log" ]]
+work_volume_mounted() { "$mount_cli" | grep -Fq " on ${work_volume} ("; }
 
 runner_log="$test_root/runner.log"
 gh_log="$test_root/gh.log"

--- a/tests/trips-android-host-runner-controller-test.zsh
+++ b/tests/trips-android-host-runner-controller-test.zsh
@@ -105,6 +105,17 @@ work_volume_mounted
 prepare_work_root
 [[ -d "$test_root/work-volume/work" && -w "$test_root/work-volume/work" ]]
 [[ "$PWD" == "$test_root/work-volume" ]]
+mount_check_count=0
+work_volume_mounted() {
+  mount_check_count=$((mount_check_count + 1))
+  (( mount_check_count == 1 ))
+}
+if prepare_work_root; then
+  print -u2 -- 'work-root setup must fail if the mount disappears after entering the volume'
+  exit 1
+fi
+[[ "$mount_check_count" -eq 2 ]]
+work_volume_mounted() { "$mount_cli" | grep -Fq " on ${work_volume} ("; }
 if TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true TRIPS_ANDROID_WORK_VOLUME="$test_root/not-mounted" TRIPS_ANDROID_WORK_ROOT="$test_root/not-mounted/work" \
   TRIPS_ANDROID_MOUNT_CLI="$fake_mount" zsh -c 'source "$1"; work_volume_mounted' zsh "$repo_root/scripts/trips-android-host-runner-controller.zsh"; then
   print -u2 -- 'an absent external Android work volume must fail closed'

--- a/tests/trips-android-host-runner-controller-test.zsh
+++ b/tests/trips-android-host-runner-controller-test.zsh
@@ -5,6 +5,7 @@ repo_root="${0:A:h:h}"
 test_root=$(mktemp -d "${repo_root}/tmp/android-host-controller.XXXXXX")
 trap '/bin/rm -rf -- "$test_root"' EXIT
 mkdir -p "$test_root/sdk/emulator"
+mkdir -p "$test_root/work-volume"
 cat >"$test_root/sdk/emulator/emulator" <<'SCRIPT'
 #!/bin/zsh
 case "${FAKE_ACCEL:-ok}" in
@@ -63,6 +64,13 @@ esac
 SCRIPT
 chmod 700 "$fake_gh"
 
+fake_mount="$test_root/mount"
+cat >"$fake_mount" <<SCRIPT
+#!/bin/zsh
+print -r -- '/dev/disk99s1 on ${test_root}/work-volume (apfs, local, journaled)'
+SCRIPT
+chmod 700 "$fake_mount"
+
 mkdir -p "$test_root/runner-root"
 cat >"$test_root/runner-root/config.sh" <<'SCRIPT'
 #!/bin/zsh
@@ -83,13 +91,21 @@ TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true \
   TRIPS_ANDROID_SDK_ROOT="$test_root/sdk" \
   TRIPS_ANDROID_GH_CLI="$fake_gh" \
   TRIPS_ANDROID_RUNNER_ROOT="$test_root/runner-root" \
-  TRIPS_ANDROID_WORK_ROOT="$test_root/work" \
+  TRIPS_ANDROID_WORK_VOLUME="$test_root/work-volume" \
+  TRIPS_ANDROID_WORK_ROOT="$test_root/work-volume/work" \
+  TRIPS_ANDROID_MOUNT_CLI="$fake_mount" \
   TRIPS_ANDROID_CLAIM_TIMEOUT_SECONDS=0 \
   TRIPS_ANDROID_CLAIM_POLL_SECONDS=0 \
   TRIPS_ANDROID_TERMINATION_GRACE_SECONDS=0 \
   source "$repo_root/scripts/trips-android-host-runner-controller.zsh"
 [[ -x "$repo_root/scripts/start-trips-android-host-runner.zsh" ]]
 [[ -x "$repo_root/scripts/trips-android-host-runner-controller.zsh" ]]
+work_volume_mounted
+if TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true TRIPS_ANDROID_WORK_VOLUME="$test_root/not-mounted" TRIPS_ANDROID_WORK_ROOT="$test_root/not-mounted/work" \
+  TRIPS_ANDROID_MOUNT_CLI="$fake_mount" zsh -c 'source "$1"; work_volume_mounted' zsh "$repo_root/scripts/trips-android-host-runner-controller.zsh"; then
+  print -u2 -- 'an absent external Android work volume must fail closed'
+  exit 1
+fi
 FAKE_ACCEL=ok emulator_acceleration_healthy
 if FAKE_ACCEL=header-only emulator_acceleration_healthy; then
   print -u2 -- 'acceleration header without usability text must fail'
@@ -148,7 +164,7 @@ if FAKE_GH_SCENARIO=runner FAKE_RUNNER_LOG="$runner_log" FAKE_GH_LOG="$gh_log" F
 fi
 grep -qx config "$runner_log"
 gradle_home="$(sed -n 's/^gradle=//p' "$runner_log")"
-[[ "$gradle_home" == "$test_root/work/job-"*/gradle ]]
+[[ "$gradle_home" == "$test_root/work-volume/work/job-"*/gradle ]]
 if grep -qx run "$runner_log"; then
   print -u2 -- 'runner execution must not start after configuration failure'
   exit 1
@@ -163,7 +179,7 @@ if FAKE_GH_SCENARIO=runner FAKE_RUNNER_LOG="$runner_log" FAKE_GH_LOG="$gh_log" F
 fi
 grep -qx config "$runner_log"
 gradle_home="$(sed -n 's/^gradle=//p' "$runner_log")"
-[[ "$gradle_home" == "$test_root/work/job-"*/gradle ]]
+[[ "$gradle_home" == "$test_root/work-volume/work/job-"*/gradle ]]
 grep -qx run "$runner_log"
 grep -qx delete "$gh_log"
 

--- a/tests/trips-android-host-runner-controller-test.zsh
+++ b/tests/trips-android-host-runner-controller-test.zsh
@@ -104,6 +104,7 @@ work_volume_mounted
 [[ ! -e "$test_root/work-volume/work" ]]
 prepare_work_root
 [[ -d "$test_root/work-volume/work" && -w "$test_root/work-volume/work" ]]
+[[ "$PWD" == "$test_root/work-volume" ]]
 if TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true TRIPS_ANDROID_WORK_VOLUME="$test_root/not-mounted" TRIPS_ANDROID_WORK_ROOT="$test_root/not-mounted/work" \
   TRIPS_ANDROID_MOUNT_CLI="$fake_mount" zsh -c 'source "$1"; work_volume_mounted' zsh "$repo_root/scripts/trips-android-host-runner-controller.zsh"; then
   print -u2 -- 'an absent external Android work volume must fail closed'


### PR DESCRIPTION
## Summary

- Refuse Android runner startup unless the external `/Volumes/RunnerWork` mount is genuinely present.
- Prevents root-volume fallback while the work disk is detached.

## Related Issue

Closes #139

## Validation

- `tests/trips-android-host-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`