### PR TITLE
fix(ci): parallelize same-repository Linux jobs

### DIFF
--- a/scripts/trips-linux-lima-runner-controller.zsh
+++ b/scripts/trips-linux-lima-runner-controller.zsh
@@ -610,7 +610,7 @@ wait_for_guest_package_manager() {
 }
 
 run_one_ephemeral_runner() {
-  local repository="$1" suffix vm_name token runner_name runner_pid runner_status
+  local repository="$1" suffix vm_name token runner_name runner_pid runner_status claim_result
   local vm_cleanup_required=false
   suffix="$(/bin/date -u '+%Y%m%d%H%M%S')-$$"
   vm_name="trips-linux-runner-${slot}-job-${suffix}"
@@ -648,7 +648,10 @@ run_one_ephemeral_runner() {
       bash -lc "IFS= read -r registration_token; cd '$runner_root'; ./config.sh --unattended --ephemeral --disableupdate --url 'https://github.com/${repository}' --token \"\$registration_token\" --name '$runner_name' --labels '$runner_labels' --work _work; exec ./run.sh" &
     runner_pid=$!
     wait_for_runner_claim "$repository" "$runner_name" "$runner_pid"
-    local claim_result=$?
+    claim_result=$?
+    # Once GitHub marks this runner busy, it owns exactly one queued job and the
+    # other slot can safely provision another ephemeral runner for this repo.
+    (( claim_result == 0 )) && release_selection_lock
     resolve_runner_status "$claim_result" "$runner_pid" "$runner_name" || return 1
     runner_status="$REPLY"
   } always {

--- a/tests/trips-linux-lima-runner-controller-test.zsh
+++ b/tests/trips-linux-lima-runner-controller-test.zsh
@@ -293,6 +293,36 @@ assert_equal jai/tonegate "${clone_failure_cleanup[1]}"
   exit 1
 }
 
+acquire_selection_lock jai/tonegate
+claimed_repository_lock="$selected_repository_lock"
+typeset production_wait_for_guest_package_manager="${functions[wait_for_guest_package_manager]}"
+typeset production_registration_token="${functions[registration_token]}"
+typeset production_wait_for_runner_claim="${functions[wait_for_runner_claim]}"
+typeset production_resolve_runner_status="${functions[resolve_runner_status]}"
+typeset -g claim_resolution_lock_state=""
+repository_is_private() { return 0; }
+wait_for_guest_package_manager() { return 0; }
+registration_token() { REPLY=test-token; }
+wait_for_runner_claim() { return 0; }
+resolve_runner_status() {
+  if [[ -n "$selected_repository_lock" || -d "$claimed_repository_lock" ]]; then
+    claim_resolution_lock_state=locked
+  else
+    claim_resolution_lock_state=unlocked
+  fi
+  wait "$2" 2>/dev/null || true
+  REPLY=0
+}
+cleanup_runner_vm() { return 0; }
+run_one_ephemeral_runner jai/tonegate
+assert_equal unlocked "$claim_resolution_lock_state"
+functions[repository_is_private]="$production_repository_is_private"
+functions[wait_for_guest_package_manager]="$production_wait_for_guest_package_manager"
+functions[registration_token]="$production_registration_token"
+functions[wait_for_runner_claim]="$production_wait_for_runner_claim"
+functions[resolve_runner_status]="$production_resolve_runner_status"
+functions[cleanup_runner_vm]="$production_cleanup_runner_vm"
+
 clone_signal_home="${test_directory}/clone-signal-home"
 clone_signal_started="${test_directory}/clone-signal-started"
 clone_signal_cleanup="${test_directory}/clone-signal-cleanup"


### PR DESCRIPTION
## Summary
- release a repository reservation once GitHub confirms the ephemeral runner has claimed its one job
- retain the reservation through cleanup on registration, early-exit, and idle-timeout failures
- add deterministic executable coverage for lock state at claim resolution

## Related Issue
Closes #134

## Validation
- `tests/trips-linux-lima-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`