### PR TITLE
fix(ci): use durable Tart runner labels

### DIFF
--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -13,7 +13,9 @@ readonly base_memory_mb="${TRIPS_TART_BASE_MEMORY_MB:-16384}"
 readonly runner_root="/Users/admin/actions-runner"
 readonly runner_host_label="${TRIPS_TART_RUNNER_HOST_LABEL:-borg-cube-03}"
 readonly runner_name_prefix="${TRIPS_TART_RUNNER_NAME_PREFIX:-${runner_host_label}}"
-readonly runner_labels="${runner_host_label},tart,ios"
+# Host placement is controller-owned. GitHub workflows use durable capability
+# labels so another eligible Borg controller can claim a job after host failure.
+readonly runner_labels="${TRIPS_TART_RUNNER_LABELS:-tart,ios}"
 readonly private_key="/Users/jai/.config/trips-tart-runner/github-app-private-key.pem"
 readonly ssh_key="/Users/jai/.config/trips-tart-runner/runner-controller-ed25519"
 readonly log_directory="/Users/jai/Library/Logs/trips-tart-runner"
@@ -233,13 +235,11 @@ workflow_run_oldest_queued_job_timestamp() {
     --paginate --slurp \
     "repos/${repository}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" |
     /usr/bin/python3 -c 'import json,sys
-host=sys.argv[1].lower()
 required={"self-hosted","macos","arm64","tart","ios"}
-allowed=required|{host}
 pages=json.load(sys.stdin)
 jobs=[job for page in pages for job in page.get("jobs",[])]
-matches=[job.get("created_at","") for job in jobs if job.get("status") == "queued" and required <= {str(label).lower() for label in job.get("labels",[])} <= allowed and job.get("created_at")]
-print(min(matches) if matches else "")' "$runner_host_label" || return 2
+matches=[job.get("created_at","") for job in jobs if job.get("status") == "queued" and {str(label).lower() for label in job.get("labels",[])} == required and job.get("created_at")]
+print(min(matches) if matches else "")' || return 2
 }
 
 repository_oldest_queued_job_timestamp() {

--- a/tests/trips-tart-runner-controller-test.zsh
+++ b/tests/trips-tart-runner-controller-test.zsh
@@ -24,14 +24,14 @@ case "${FAKE_SCENARIO:-}" in
     if [[ "$request" == *'repos/jai/trips-frontend/actions/runs?'* ]]; then
       print -r -- $'202\t2026-08-25T00:00:00Z\tjai/trips-frontend'
     elif [[ "$request" == *'repos/jai/trips-frontend/actions/runs/202/jobs?'* ]]; then
-      print -r -- '[{"jobs":[{"status":"queued","created_at":"2026-08-25T00:00:02Z","labels":["self-hosted","macOS","ARM64","tart","ios","borg-cube-03"]}]}]'
+      print -r -- '[{"jobs":[{"status":"queued","created_at":"2026-08-25T00:00:02Z","labels":["self-hosted","macOS","ARM64","tart","ios"]}]}]'
     fi
     ;;
   incompatible-host)
     if [[ "$request" == *'repos/jai/trips-frontend/actions/runs?'* ]]; then
       print -r -- $'303\t2026-08-25T00:00:00Z\tjai/trips-frontend'
     elif [[ "$request" == *'repos/jai/trips-frontend/actions/runs/303/jobs?'* ]]; then
-      print -r -- '[{"jobs":[{"status":"queued","created_at":"2026-08-25T00:00:03Z","labels":["self-hosted","macOS","ARM64","tart","ios","another-host"]}]}]'
+      print -r -- '[{"jobs":[{"status":"queued","created_at":"2026-08-25T00:00:03Z","labels":["self-hosted","macOS","ARM64","tart","ios","borg-cube-03"]}]}]'
     fi
     ;;
   no-jobs)
@@ -57,7 +57,7 @@ request="$*"
 if [[ "$request" == *'actions/runners?per_page=100&page=1'* ]]; then
   /usr/bin/python3 -c 'import json; print(json.dumps({"runners":[{"id":i,"name":f"other-{i}","busy":False} for i in range(100)]}))'
 elif [[ "$request" == *'actions/runners?per_page=100&page=2'* ]]; then
-  print -r -- '{"runners":[{"id":4343,"name":"page-two-runner","busy":false,"labels":[{"name":"self-hosted"},{"name":"macOS"},{"name":"ARM64"},{"name":"borg-cube-03"},{"name":"tart"},{"name":"ios"}]}]}'
+  print -r -- '{"runners":[{"id":4343,"name":"page-two-runner","busy":false,"labels":[{"name":"self-hosted"},{"name":"macOS"},{"name":"ARM64"},{"name":"tart"},{"name":"ios"}]}]}'
 else
   print -u2 -- "Unexpected curl request: ${request}"
   exit 1
@@ -286,15 +286,15 @@ assert_equal 17 "$guest_preflight_status"
 assert_equal 'guest-preflight failed stage=java status=17' "$guest_preflight_output"
 
 runner_lookup 'jai/trips-frontend' 'page-two-runner'
-assert_equal $'4343\tidle\tself-hosted,macos,arm64,borg-cube-03,tart,ios' "$REPLY"
+assert_equal $'4343\tidle\tself-hosted,macos,arm64,tart,ios' "$REPLY"
 runner_busy_state 'jai/trips-frontend' 'page-two-runner'
 assert_equal idle "$REPLY"
-runner_has_expected_labels 'self-hosted,macos,arm64,borg-cube-03,tart,ios'
-if runner_has_expected_labels 'self-hosted,macos,arm64,tart,ios'; then
-  print -u2 -- 'Expected a runner missing the Borg host label to be rejected'
+runner_has_expected_labels 'self-hosted,macos,arm64,tart,ios'
+if runner_has_expected_labels 'self-hosted,macos,arm64,borg-cube-03,tart,ios'; then
+  print -u2 -- 'Expected a runner with a physical-host label to be rejected'
   exit 1
 fi
-if runner_has_expected_labels 'self-hosted,macos,arm64,borg-cube-03,tart,ios,extra'; then
+if runner_has_expected_labels 'self-hosted,macos,arm64,tart,ios,extra'; then
   print -u2 -- 'Expected a runner with an unexpected label to be rejected'
   exit 1
 fi
@@ -496,7 +496,7 @@ fi
 
 export FAKE_SCENARIO=incompatible-host
 if workflow_run_oldest_queued_job_timestamp jai/trips-frontend 303 | /usr/bin/grep -q .; then
-  print -u2 -- 'Expected a job with an incompatible host label to be rejected'
+  print -u2 -- 'Expected a job with a physical-host label to be rejected'
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Register and verify Borg Tart runners using the documented durable capability labels only.
- Keep physical-host placement controller-owned, avoiding pre-claim rejection for the existing iOS release.

## Related Issue

Closes #150

## Validation

- `zsh tests/trips-tart-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`
