### PR TITLE
fix(ci): let GitHub schedule Tart runners

### DIFF
--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -155,52 +155,10 @@ print((str(runner["id"]) + "\t" + ("busy" if runner.get("busy") else "idle") + "
   REPLY=$'\tmissing'
 }
 
-runner_label_state() {
-  local label_csv="$1" label
-  local -A expected_labels observed_labels
-  expected_labels=()
-  observed_labels=()
-  for label in self-hosted macos arm64 ${(s:,:)runner_labels}; do
-    expected_labels[${(L)label}]=1
-  done
-  for label in ${(s:,:)label_csv}; do
-    [[ -n "$label" ]] || continue
-    label="${(L)label}"
-    if [[ -z "${expected_labels[$label]-}" ]]; then
-      REPLY=unexpected
-      return 1
-    fi
-    observed_labels[$label]=1
-  done
-  if (( ${#expected_labels} != ${#observed_labels} )); then
-    REPLY=pending
-    return 1
-  fi
-  for label in ${(k)expected_labels}; do
-    if [[ -z "${observed_labels[$label]-}" ]]; then
-      REPLY=pending
-      return 1
-    fi
-  done
-  REPLY=ready
-}
-
-runner_has_expected_labels() {
-  runner_label_state "$1" && [[ "$REPLY" == ready ]]
-}
-
 runner_busy_state() {
-  local repository="$1" runner_name="$2" lookup labels
+  local repository="$1" runner_name="$2" lookup
   runner_lookup "$repository" "$runner_name" || return 1
   lookup="$REPLY"
-  labels="${lookup##*$'\t'}"
-  runner_label_state "$labels" || {
-    case "$REPLY" in
-      pending) REPLY=label-pending; return 3 ;;
-      unexpected) REPLY=label-unexpected; return 4 ;;
-      *) return 1 ;;
-    esac
-  }
   REPLY="${lookup#*$'\t'}"
   REPLY="${REPLY%%$'\t'*}"
 }
@@ -277,7 +235,7 @@ repository_oldest_queued_job_timestamp() {
 }
 
 wait_for_runner_claim() {
-  local repository="$1" runner_name="$2" runner_pid="$3" started_at now state lookup_status label_mismatch_reported=false
+  local repository="$1" runner_name="$2" runner_pid="$3" started_at now state
   started_at=$(/bin/date +%s)
   while /bin/kill -0 "$runner_pid" 2>/dev/null; do
     if runner_busy_state "$repository" "$runner_name"; then
@@ -286,29 +244,13 @@ wait_for_runner_claim() {
         return 0
       fi
     else
-      lookup_status=$?
-      if (( lookup_status == 3 )); then
-        state=label-mismatch
-        if [[ "$label_mismatch_reported" == false ]]; then
-          log "${runner_name} labels are still propagating; waiting for the canonical label set"
-          label_mismatch_reported=true
-        fi
-      elif (( lookup_status == 4 )); then
-        log "${runner_name} registered with unexpected runner labels"
-        return 4
-      else
-        state=unknown
-        log "unable to verify ${runner_name} claim state; preserving runner"
-      fi
+      state=unknown
+      log "unable to verify ${runner_name} claim state; preserving runner"
     fi
     now=$(/bin/date +%s)
     if (( now - started_at >= claim_timeout_seconds )); then
       if [[ "$state" == idle || "$state" == missing ]]; then
         return 2
-      fi
-      if [[ "$state" == label-mismatch ]]; then
-        log "${runner_name} did not expose the canonical label set before claim timeout"
-        return 3
       fi
     fi
     /bin/sleep "$claim_poll_seconds"

--- a/tests/trips-tart-runner-controller-test.zsh
+++ b/tests/trips-tart-runner-controller-test.zsh
@@ -57,7 +57,7 @@ request="$*"
 if [[ "$request" == *'actions/runners?per_page=100&page=1'* ]]; then
   /usr/bin/python3 -c 'import json; print(json.dumps({"runners":[{"id":i,"name":f"other-{i}","busy":False} for i in range(100)]}))'
 elif [[ "$request" == *'actions/runners?per_page=100&page=2'* ]]; then
-  print -r -- '{"runners":[{"id":4343,"name":"page-two-runner","busy":false,"labels":[{"name":"self-hosted"},{"name":"macOS"},{"name":"ARM64"},{"name":"tart"},{"name":"ios"}]}]}'
+  print -r -- '{"runners":[{"id":4343,"name":"page-two-runner","busy":false,"labels":[{"name":"self-hosted"},{"name":"macOS"},{"name":"ARM64"},{"name":"tart"},{"name":"ios"},{"name":"unexpected"}]}]}'
 else
   print -u2 -- "Unexpected curl request: ${request}"
   exit 1
@@ -286,28 +286,9 @@ assert_equal 17 "$guest_preflight_status"
 assert_equal 'guest-preflight failed stage=java status=17' "$guest_preflight_output"
 
 runner_lookup 'jai/trips-frontend' 'page-two-runner'
-assert_equal $'4343\tidle\tself-hosted,macos,arm64,tart,ios' "$REPLY"
+assert_equal $'4343\tidle\tself-hosted,macos,arm64,tart,ios,unexpected' "$REPLY"
 runner_busy_state 'jai/trips-frontend' 'page-two-runner'
 assert_equal idle "$REPLY"
-runner_has_expected_labels 'self-hosted,macos,arm64,tart,ios'
-if runner_label_state 'self-hosted,macos,arm64,tart'; then
-  print -u2 -- 'Expected a runner missing a canonical label to remain pending'
-  exit 1
-fi
-assert_equal pending "$REPLY"
-if runner_label_state 'self-hosted,macos,arm64,tart,ios,extra'; then
-  print -u2 -- 'Expected a runner with an extra label to be rejected'
-  exit 1
-fi
-assert_equal unexpected "$REPLY"
-if runner_has_expected_labels 'self-hosted,macos,arm64,borg-cube-03,tart,ios'; then
-  print -u2 -- 'Expected a runner with a physical-host label to be rejected'
-  exit 1
-fi
-if runner_has_expected_labels 'self-hosted,macos,arm64,tart,ios,extra'; then
-  print -u2 -- 'Expected a runner with an unexpected label to be rejected'
-  exit 1
-fi
 
 (
   sleep 3
@@ -315,38 +296,6 @@ fi
 fake_runner_pid=$!
 runner_busy_state() { REPLY=busy; }
 wait_for_runner_claim 'jai/trips-frontend' 'test-runner' "$fake_runner_pid"
-kill "$fake_runner_pid" 2>/dev/null || true
-wait "$fake_runner_pid" 2>/dev/null || true
-
-label_probe_count=0
-(
-  sleep 3
-) &
-fake_runner_pid=$!
-runner_busy_state() {
-  label_probe_count=$((label_probe_count + 1))
-  if (( label_probe_count < 3 )); then
-    REPLY=label-mismatch
-    return 3
-  fi
-  REPLY=busy
-}
-wait_for_runner_claim 'jai/trips-frontend' 'test-runner' "$fake_runner_pid"
-assert_equal 3 "$label_probe_count"
-kill "$fake_runner_pid" 2>/dev/null || true
-wait "$fake_runner_pid" 2>/dev/null || true
-
-(
-  sleep 3
-) &
-fake_runner_pid=$!
-runner_busy_state() { REPLY=label-unexpected; return 4; }
-if wait_for_runner_claim 'jai/trips-frontend' 'test-runner' "$fake_runner_pid"; then
-  print -u2 -- 'Expected a runner with an unexpected label to fail closed'
-  exit 1
-else
-  assert_equal 4 "$?"
-fi
 kill "$fake_runner_pid" 2>/dev/null || true
 wait "$fake_runner_pid" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Remove the controller-side exact-label gate after GitHub runner registration.
- Keep the controller responsible for private-repository eligibility, disposable VM lifecycle, claim timeout, and cleanup; leave job-label matching to GitHub Actions.

## Related Issue

Closes #151

## Validation

- `zsh tests/trips-tart-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`