### PR TITLE
fix(ci): verify CocoaPods in Tart base

### DIFF
--- a/scripts/provision-tart-runner-base.zsh
+++ b/scripts/provision-tart-runner-base.zsh
@@ -24,7 +24,7 @@ base_name_is_safe() {
 }
 
 base_root_preflight_command() {
-  printf '%s' 'set -e; test "$(df -g / | awk '\''NR == 2 {print $4}'\'')" -ge "${TRIPS_TART_MINIMUM_ROOT_FREE_GIB:-5}"; xcodebuild -version >/dev/null; java -version >/dev/null 2>&1; test -x /Users/admin/actions-runner/bin/Runner.Listener; xcrun simctl list runtimes | grep -q "iOS"'
+  printf '%s' 'set -e; test "$(df -g / | awk '\''NR == 2 {print $4}'\'')" -ge "${TRIPS_TART_MINIMUM_ROOT_FREE_GIB:-5}"; xcodebuild -version >/dev/null; /opt/homebrew/bin/java -version >/dev/null 2>&1; /opt/homebrew/bin/pod --version >/dev/null 2>&1; test -x /Users/admin/actions-runner/bin/Runner.Listener; xcrun simctl list runtimes | grep -q "iOS"'
 }
 
 verify_base() {

--- a/tests/provision-tart-runner-base-test.zsh
+++ b/tests/provision-tart-runner-base-test.zsh
@@ -50,6 +50,7 @@ TRIPS_TART_BASE_LIBRARY_ONLY=false \
 zsh "${repo_root}/scripts/provision-tart-runner-base.zsh" --verify
 [[ "$(sed -n '1p' "$fake_log")" == 'list --source local --quiet' ]]
 [[ "$(sed -n '2p' "$fake_log")" == exec\ trips-runner-base-next\ /bin/zsh\ -lc\ * ]]
+grep -q '/opt/homebrew/bin/pod --version' "$fake_log"
 
 if FAKE_TART_LOG="$fake_log" \
   FAKE_BASE_NAME=trips-runner-base-next \


### PR DESCRIPTION
## Summary

- Require the canonical CocoaPods binary and Java binary when verifying a candidate Tart base.
- Prevent a base without CocoaPods from reaching the Expo CNG/Fastlane release path.

## Related Issue

Fixes #151

## Validation

- `zsh tests/provision-tart-runner-base-test.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`
