### PR TITLE
fix(ci): use Borg main disk for Android runner

### DIFF
--- a/scripts/trips-android-host-runner-controller.zsh
+++ b/scripts/trips-android-host-runner-controller.zsh
@@ -6,18 +6,15 @@ PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 readonly repository="${TRIPS_ANDROID_REPOSITORY:-jai/trips-frontend}"
 readonly host_label="${TRIPS_ANDROID_HOST_LABEL:-borg-cube-03}"
 readonly runner_root="${TRIPS_ANDROID_RUNNER_ROOT:-/Users/jai/.local/share/trips-android-host-runner/actions-runner}"
-readonly work_root="${TRIPS_ANDROID_WORK_ROOT:-/Volumes/RunnerWork/android-host-jobs}"
-readonly sdk_root="${TRIPS_ANDROID_SDK_ROOT:-/Volumes/RunnerWork/android-sdk}"
-readonly android_user_home="${TRIPS_ANDROID_USER_HOME:-/Volumes/RunnerWork/android-user}"
-readonly avd_root="${TRIPS_ANDROID_AVD_ROOT:-${android_user_home}/.android/avd}"
-readonly work_volume="${TRIPS_ANDROID_WORK_VOLUME:-/Volumes/RunnerWork}"
-readonly work_root_relative="${work_root#${work_volume}/}"
+readonly work_root="${TRIPS_ANDROID_WORK_ROOT:-/Users/jai/.local/share/trips-android-host-runner/jobs}"
+readonly sdk_root="${TRIPS_ANDROID_SDK_ROOT:-/Users/jai/Library/Android/sdk}"
+readonly android_user_home="${TRIPS_ANDROID_USER_HOME:-/Users/jai/.android}"
+readonly avd_root="${TRIPS_ANDROID_AVD_ROOT:-${android_user_home}/avd}"
 readonly lock_path="${TRIPS_ANDROID_NATIVE_LANE_LOCK:-/Users/jai/Library/Logs/trips-tart-native-lane.lock}"
 readonly controller_lock="${TRIPS_ANDROID_CONTROLLER_LOCK:-/Users/jai/Library/Logs/trips-android-host-runner/controller.lock}"
 readonly gh_cli="${TRIPS_ANDROID_GH_CLI:-/opt/homebrew/bin/gh}"
 readonly shlock_cli="${TRIPS_ANDROID_SHLOCK_CLI:-/usr/bin/shlock}"
 readonly pgrep_cli="${TRIPS_ANDROID_PGREP_CLI:-/usr/bin/pgrep}"
-readonly mount_cli="${TRIPS_ANDROID_MOUNT_CLI:-/sbin/mount}"
 readonly minimum_free_gib="${TRIPS_ANDROID_MINIMUM_FREE_GIB:-5}"
 readonly claim_timeout_seconds="${TRIPS_ANDROID_CLAIM_TIMEOUT_SECONDS:-300}"
 readonly claim_poll_seconds="${TRIPS_ANDROID_CLAIM_POLL_SECONDS:-2}"
@@ -46,7 +43,7 @@ android_preflight() {
   [[ "$(scutil --get ComputerName)" == "$host_label" ]] || return 1
   prepare_work_root || return 1
   [[ "$(df -g / | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
-  [[ "$(df -g "$work_root_relative" | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
+  [[ "$(df -g "$work_root" | awk 'NR == 2 { print $4 }')" -ge "$minimum_free_gib" ]] || return 1
   [[ -x "$runner_root/bin/Runner.Listener" ]] || return 1
   [[ -x "$sdk_root/emulator/emulator" && -x "$sdk_root/platform-tools/adb" ]] || return 1
   [[ -d "$android_user_home" && -w "$android_user_home" && -d "$avd_root" && -w "$avd_root" ]] || return 1
@@ -56,18 +53,10 @@ android_preflight() {
     "$sdk_root/emulator/emulator" -list-avds | grep -qx ci-android-arm64
 }
 
-work_volume_mounted() {
-  [[ "$work_root" == "$work_volume"/* && "$work_root_relative" != "$work_root" ]] || return 1
-  "$mount_cli" | grep -Fq " on ${work_volume} ("
-}
-
 prepare_work_root() {
-  work_volume_mounted || return 1
-  cd "$work_volume" || return 1
-  work_volume_mounted || return 1
-  [[ "$PWD" == "$work_volume" ]] || return 1
-  mkdir -p "$work_root_relative" || return 1
-  [[ -d "$work_root_relative" && -w "$work_root_relative" ]]
+  mkdir -p "$work_root" || return 1
+  cd "$work_root" || return 1
+  [[ "$PWD" == "$work_root" && -w "$work_root" ]]
 }
 
 emulator_acceleration_healthy() {
@@ -165,7 +154,7 @@ run_one_job() {
   local suffix job_root job_root_absolute runner_name token runner_pid runner_status claim_status
   prepare_work_root || return 1
   suffix="$(date -u '+%Y%m%d%H%M%S')-$$"
-  job_root="${work_root_relative}/job-${suffix}"
+  job_root="${work_root}/job-${suffix}"
   runner_name="${host_label}-android-${suffix}"
   mkdir -p "$job_root/tmp" "$job_root/npm" "$job_root/gradle" "$job_root/work"
   [[ -w "$job_root/tmp" && -w "$job_root/npm" && -w "$job_root/gradle" && -w "$job_root/work" ]] || {
@@ -224,7 +213,6 @@ main() {
   trap 'exit 143' INT TERM
   "$gh_cli" auth status >/dev/null 2>&1 || return 1
   while true; do
-    work_volume_mounted || { log 'Android external work volume is not mounted; refusing runner registration'; sleep 30; continue; }
     queued_android_job_exists || { sleep 30; continue; }
     acquire_lock "$lock_path" || { sleep 15; continue; }
     native_lock_owned=true

--- a/tests/trips-android-host-runner-controller-test.zsh
+++ b/tests/trips-android-host-runner-controller-test.zsh
@@ -5,7 +5,7 @@ repo_root="${0:A:h:h}"
 test_root=$(mktemp -d "${repo_root}/tmp/android-host-controller.XXXXXX")
 trap '/bin/rm -rf -- "$test_root"' EXIT
 mkdir -p "$test_root/sdk/emulator"
-mkdir -p "$test_root/work-volume"
+mkdir -p "$test_root/android-user/avd"
 cat >"$test_root/sdk/emulator/emulator" <<'SCRIPT'
 #!/bin/zsh
 case "${FAKE_ACCEL:-ok}" in
@@ -64,13 +64,6 @@ esac
 SCRIPT
 chmod 700 "$fake_gh"
 
-fake_mount="$test_root/mount"
-cat >"$fake_mount" <<SCRIPT
-#!/bin/zsh
-print -r -- '/dev/disk99s1 on ${test_root}/work-volume (apfs, local, journaled)'
-SCRIPT
-chmod 700 "$fake_mount"
-
 mkdir -p "$test_root/runner-root"
 cat >"$test_root/runner-root/config.sh" <<'SCRIPT'
 #!/bin/zsh
@@ -91,36 +84,25 @@ chmod 700 "$test_root/runner-root/config.sh" "$test_root/runner-root/run.sh"
 
 TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true \
   TRIPS_ANDROID_SDK_ROOT="$test_root/sdk" \
+  TRIPS_ANDROID_USER_HOME="$test_root/android-user" \
+  TRIPS_ANDROID_AVD_ROOT="$test_root/android-user/avd" \
   TRIPS_ANDROID_GH_CLI="$fake_gh" \
   TRIPS_ANDROID_RUNNER_ROOT="$test_root/runner-root" \
-  TRIPS_ANDROID_WORK_VOLUME="$test_root/work-volume" \
-  TRIPS_ANDROID_WORK_ROOT="$test_root/work-volume/work" \
-  TRIPS_ANDROID_MOUNT_CLI="$fake_mount" \
+  TRIPS_ANDROID_WORK_ROOT="$test_root/work-root" \
   TRIPS_ANDROID_CLAIM_TIMEOUT_SECONDS=0 \
   TRIPS_ANDROID_CLAIM_POLL_SECONDS=0 \
   TRIPS_ANDROID_TERMINATION_GRACE_SECONDS=0 \
   source "$repo_root/scripts/trips-android-host-runner-controller.zsh"
 [[ -x "$repo_root/scripts/start-trips-android-host-runner.zsh" ]]
 [[ -x "$repo_root/scripts/trips-android-host-runner-controller.zsh" ]]
-work_volume_mounted
-[[ ! -e "$test_root/work-volume/work" ]]
+[[ ! -e "$test_root/work-root" ]]
 prepare_work_root
-[[ -d "$test_root/work-volume/work" && -w "$test_root/work-volume/work" ]]
-[[ "$PWD" == "$test_root/work-volume" ]]
-mount_check_count=0
-work_volume_mounted() {
-  mount_check_count=$((mount_check_count + 1))
-  (( mount_check_count == 1 ))
-}
-if prepare_work_root; then
-  print -u2 -- 'work-root setup must fail if the mount disappears after entering the volume'
-  exit 1
-fi
-[[ "$mount_check_count" -eq 2 ]]
-work_volume_mounted() { "$mount_cli" | grep -Fq " on ${work_volume} ("; }
-if TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true TRIPS_ANDROID_WORK_VOLUME="$test_root/not-mounted" TRIPS_ANDROID_WORK_ROOT="$test_root/not-mounted/work" \
-  TRIPS_ANDROID_MOUNT_CLI="$fake_mount" zsh -c 'source "$1"; work_volume_mounted' zsh "$repo_root/scripts/trips-android-host-runner-controller.zsh"; then
-  print -u2 -- 'an absent external Android work volume must fail closed'
+[[ -d "$test_root/work-root" && -w "$test_root/work-root" ]]
+[[ "$PWD" == "$test_root/work-root" ]]
+if TRIPS_ANDROID_CONTROLLER_LIBRARY_ONLY=true zsh -c 'source "$1"; [[ "$work_root" == /Users/jai/.local/share/trips-android-host-runner/jobs && "$sdk_root" == /Users/jai/Library/Android/sdk && "$android_user_home" == /Users/jai/.android && "$avd_root" == /Users/jai/.android/avd ]]' zsh "$repo_root/scripts/trips-android-host-runner-controller.zsh"; then
+  :
+else
+  print -u2 -- 'Android host controller defaults must use Borg main-disk paths'
   exit 1
 fi
 FAKE_ACCEL=ok emulator_acceleration_healthy
@@ -170,18 +152,6 @@ else
   [[ $? -eq 2 ]]
 fi
 
-runner_log="$test_root/mount-loss-runner.log"
-gh_log="$test_root/mount-loss-gh.log"
-: >"$runner_log"
-: >"$gh_log"
-work_volume_mounted() { return 1; }
-if FAKE_GH_SCENARIO=runner FAKE_RUNNER_LOG="$runner_log" FAKE_GH_LOG="$gh_log" run_one_job; then
-  print -u2 -- 'runner creation must fail closed when the external work volume is lost'
-  exit 1
-fi
-[[ ! -s "$runner_log" && ! -s "$gh_log" ]]
-work_volume_mounted() { "$mount_cli" | grep -Fq " on ${work_volume} ("; }
-
 runner_log="$test_root/runner.log"
 gh_log="$test_root/gh.log"
 : >"$runner_log"
@@ -193,9 +163,9 @@ if FAKE_GH_SCENARIO=runner FAKE_RUNNER_LOG="$runner_log" FAKE_GH_LOG="$gh_log" F
 fi
 grep -qx config "$runner_log"
 gradle_home="$(sed -n 's/^gradle=//p' "$runner_log")"
-[[ "$gradle_home" == "$test_root/work-volume/work/job-"*/gradle ]]
-grep -qx "android_user=/Volumes/RunnerWork/android-user" "$runner_log"
-grep -qx "avd=/Volumes/RunnerWork/android-user/.android/avd" "$runner_log"
+[[ "$gradle_home" == "$test_root/work-root/job-"*/gradle ]]
+grep -qx "android_user=$test_root/android-user" "$runner_log"
+grep -qx "avd=$test_root/android-user/avd" "$runner_log"
 if grep -qx run "$runner_log"; then
   print -u2 -- 'runner execution must not start after configuration failure'
   exit 1
@@ -210,9 +180,9 @@ if FAKE_GH_SCENARIO=runner FAKE_RUNNER_LOG="$runner_log" FAKE_GH_LOG="$gh_log" F
 fi
 grep -qx config "$runner_log"
 gradle_home="$(sed -n 's/^gradle=//p' "$runner_log")"
-[[ "$gradle_home" == "$test_root/work-volume/work/job-"*/gradle ]]
-grep -qx "android_user=/Volumes/RunnerWork/android-user" "$runner_log"
-grep -qx "avd=/Volumes/RunnerWork/android-user/.android/avd" "$runner_log"
+[[ "$gradle_home" == "$test_root/work-root/job-"*/gradle ]]
+grep -qx "android_user=$test_root/android-user" "$runner_log"
+grep -qx "avd=$test_root/android-user/avd" "$runner_log"
 grep -qx run "$runner_log"
 grep -qx delete "$gh_log"
 


### PR DESCRIPTION
## Summary
- remove the false external-volume prerequisite from the Android host controller
- default disposable work, SDK, and AVD state to the documented Borg main-disk paths
- preserve the native-lane lock, one-job registration, and deterministic cleanup

## Related Issue
Closes jai/trips-ci#147

## Validation
- `zsh tests/trips-android-host-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`