### PR TITLE
fix(ci): allow Eve to share native Tart capacity

### DIFF
--- a/scripts/start-trips-tart-runner.zsh
+++ b/scripts/start-trips-tart-runner.zsh
@@ -8,4 +8,5 @@ export TRIPS_TART_RUNNER_HOST_LABEL="borg-cube-03"
 export TRIPS_TART_RUNNER_NAME_PREFIX="borg-cube-03-tart"
 export TRIPS_TART_WORK_DISK_DIRECTORY="${TRIPS_TART_WORK_DISK_DIRECTORY:-/Users/jai/.local/share/trips-tart-runner/work-disks}"
 export TRIPS_TART_NETWORK_MODE="${TRIPS_TART_NETWORK_MODE:-shared}"
+export TRIPS_TART_ALLOWED_CORESIDENT_VMS="${TRIPS_TART_ALLOWED_CORESIDENT_VMS:-atlas-eve-alpha}"
 exec /Users/jai/.local/bin/trips-tart-runner-controller

--- a/scripts/trips-tart-runner-controller.zsh
+++ b/scripts/trips-tart-runner-controller.zsh
@@ -10,6 +10,7 @@ readonly -a repository_list=(${(s:,:)repositories})
 readonly base_vm="${TRIPS_TART_BASE_VM:-trips-runner-base}"
 readonly base_cpus="${TRIPS_TART_BASE_CPUS:-4}"
 readonly base_memory_mb="${TRIPS_TART_BASE_MEMORY_MB:-16384}"
+readonly allowed_coresident_vms="${TRIPS_TART_ALLOWED_CORESIDENT_VMS:-}"
 readonly runner_root="/Users/admin/actions-runner"
 readonly runner_host_label="${TRIPS_TART_RUNNER_HOST_LABEL:-borg-cube-03}"
 readonly runner_name_prefix="${TRIPS_TART_RUNNER_NAME_PREFIX:-${runner_host_label}}"
@@ -336,9 +337,10 @@ native_capacity_available() {
     REPLY=""
     return 2
   }
-  REPLY=$(printf '%s' "$inventory" | /usr/bin/python3 -c 'import json,sys
+  REPLY=$(printf '%s' "$inventory" | TRIPS_TART_ALLOWED_CORESIDENT_VMS="$allowed_coresident_vms" /usr/bin/python3 -c 'import json,os,sys
 vms=json.load(sys.stdin)
-print("\n".join(str(vm.get("Name", "")) for vm in vms if vm.get("Name") and (vm.get("Running") is True or vm.get("State") != "stopped")))') || {
+allowed={name.strip() for name in os.environ["TRIPS_TART_ALLOWED_CORESIDENT_VMS"].split(",") if name.strip()}
+print("\n".join(str(vm.get("Name", "")) for vm in vms if vm.get("Name") and vm.get("Name") not in allowed and (vm.get("Running") is True or vm.get("State") != "stopped")))') || {
     REPLY=""
     return 2
   }

--- a/tests/trips-tart-runner-controller-test.zsh
+++ b/tests/trips-tart-runner-controller-test.zsh
@@ -123,6 +123,7 @@ export TRIPS_TART_CLAIM_TIMEOUT_SECONDS=2
 export TRIPS_TART_CLAIM_POLL_SECONDS=0.1
 export TRIPS_TART_CONTROLLER_LOCK="${test_directory}/controller.lock"
 export TRIPS_TART_NATIVE_LANE_LOCK="${test_directory}/native-lane.lock"
+export TRIPS_TART_ALLOWED_CORESIDENT_VMS='atlas-eve-alpha'
 source "${repo_root}/scripts/trips-tart-runner-controller.zsh"
 installation_token_value=test-token
 installation_token_expires_at=4102444800
@@ -386,6 +387,9 @@ else
   assert_equal 1 "$?"
   assert_equal tonegate-search-20260825 "$REPLY"
 fi
+export FAKE_RUNNING_VM=atlas-eve-alpha
+native_capacity_available
+assert_equal '' "$REPLY"
 export FAKE_RUNNING_VM=''
 native_capacity_available
 assert_equal '' "$REPLY"


### PR DESCRIPTION
## Summary
- reserve the existing native mutex for Trips job VMs while allowing the exact `atlas-eve-alpha` VM to coexist
- keep all unknown or unlisted active Tart VMs fail-closed
- source-control the Borg allowlist in the Tart runner startup wrapper

## Related Issue
Closes #156

## Validation
- `zsh tests/trips-tart-runner-controller-test.zsh`
- `scripts/validate-workflows.sh`
- `git diff --check`